### PR TITLE
Add webview downloads

### DIFF
--- a/Planet.xcodeproj/project.pbxproj
+++ b/Planet.xcodeproj/project.pbxproj
@@ -17,7 +17,14 @@
 		2A441BB027C4DD980008A694 /* CreatePlanetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A441BAF27C4DD980008A694 /* CreatePlanetView.swift */; };
 		2A441BB327C4DF110008A694 /* FollowPlanetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A441BB227C4DF110008A694 /* FollowPlanetView.swift */; };
 		2A69F04727E1B53A00141DC0 /* FeedKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2A69F04627E1B53A00141DC0 /* FeedKit */; };
+		2A7022ED2897DF1700022F13 /* PlanetDownloadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7022EC2897DF1700022F13 /* PlanetDownloadsView.swift */; };
+		2A7022F02897DF3100022F13 /* PlanetDownloadsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7022EF2897DF3100022F13 /* PlanetDownloadsWindowController.swift */; };
+		2A7022F22897DF4600022F13 /* PlanetDownloadsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7022F12897DF4600022F13 /* PlanetDownloadsWindow.swift */; };
+		2A7022F42897DF5700022F13 /* PlanetDownloadsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7022F32897DF5700022F13 /* PlanetDownloadsViewController.swift */; };
+		2A7022F62897E00600022F13 /* PlanetDownloadsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7022F52897E00600022F13 /* PlanetDownloadsViewModel.swift */; };
 		2A780CF927C76EF0007DC36A /* MyPlanetAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A780CF827C76EF0007DC36A /* MyPlanetAvatarView.swift */; };
+		2A79FB2C2898184100F06DDF /* PlanetDownloadModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A79FB2B2898184100F06DDF /* PlanetDownloadModel.swift */; };
+		2A79FB2E289819AD00F06DDF /* PlanetDownloadsItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A79FB2D289819AD00F06DDF /* PlanetDownloadsItemView.swift */; };
 		2A7D1BF427CA1B0A00D3C091 /* EditMyPlanetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7D1BF327CA1B0A00D3C091 /* EditMyPlanetView.swift */; };
 		2AC4994927BB6E7500F1C2D1 /* PlanetApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AC4994827BB6E7500F1C2D1 /* PlanetApp.swift */; };
 		2AC4994D27BB6E7600F1C2D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2AC4994C27BB6E7600F1C2D1 /* Assets.xcassets */; };
@@ -109,7 +116,14 @@
 		2A441BAD27C40BD30008A694 /* WriterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterView.swift; sourceTree = "<group>"; };
 		2A441BAF27C4DD980008A694 /* CreatePlanetView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreatePlanetView.swift; sourceTree = "<group>"; };
 		2A441BB227C4DF110008A694 /* FollowPlanetView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowPlanetView.swift; sourceTree = "<group>"; };
+		2A7022EC2897DF1700022F13 /* PlanetDownloadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetDownloadsView.swift; sourceTree = "<group>"; };
+		2A7022EF2897DF3100022F13 /* PlanetDownloadsWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetDownloadsWindowController.swift; sourceTree = "<group>"; };
+		2A7022F12897DF4600022F13 /* PlanetDownloadsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetDownloadsWindow.swift; sourceTree = "<group>"; };
+		2A7022F32897DF5700022F13 /* PlanetDownloadsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetDownloadsViewController.swift; sourceTree = "<group>"; };
+		2A7022F52897E00600022F13 /* PlanetDownloadsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetDownloadsViewModel.swift; sourceTree = "<group>"; };
 		2A780CF827C76EF0007DC36A /* MyPlanetAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPlanetAvatarView.swift; sourceTree = "<group>"; };
+		2A79FB2B2898184100F06DDF /* PlanetDownloadModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetDownloadModel.swift; sourceTree = "<group>"; };
+		2A79FB2D289819AD00F06DDF /* PlanetDownloadsItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetDownloadsItemView.swift; sourceTree = "<group>"; };
 		2A7D1BF327CA1B0A00D3C091 /* EditMyPlanetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMyPlanetView.swift; sourceTree = "<group>"; };
 		2AC4994527BB6E7500F1C2D1 /* Planet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Planet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2AC4994827BB6E7500F1C2D1 /* PlanetApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetApp.swift; sourceTree = "<group>"; };
@@ -247,6 +261,20 @@
 			path = "Create & Follow Planet";
 			sourceTree = "<group>";
 		};
+		2A7022EE2897DF1B00022F13 /* Downloads */ = {
+			isa = PBXGroup;
+			children = (
+				2A7022EC2897DF1700022F13 /* PlanetDownloadsView.swift */,
+				2A79FB2D289819AD00F06DDF /* PlanetDownloadsItemView.swift */,
+				2A7022F52897E00600022F13 /* PlanetDownloadsViewModel.swift */,
+				2A7022EF2897DF3100022F13 /* PlanetDownloadsWindowController.swift */,
+				2A7022F12897DF4600022F13 /* PlanetDownloadsWindow.swift */,
+				2A7022F32897DF5700022F13 /* PlanetDownloadsViewController.swift */,
+				2A79FB2B2898184100F06DDF /* PlanetDownloadModel.swift */,
+			);
+			path = Downloads;
+			sourceTree = "<group>";
+		};
 		2AC4993C27BB6E7500F1C2D1 = {
 			isa = PBXGroup;
 			children = (
@@ -275,6 +303,7 @@
 				7211404DFC1B4D23F84EA279 /* PlanetError.swift */,
 				2AF4003727F231F8005DF1A9 /* Writer */,
 				2A09A35D27C257E40003A0B5 /* Views */,
+				2A7022EE2897DF1B00022F13 /* Downloads */,
 				2AC4994C27BB6E7600F1C2D1 /* Assets.xcassets */,
 				2AC4995127BB6E7600F1C2D1 /* Planet.entitlements */,
 				2AC4996727BB981200F1C2D1 /* Planet.xcconfig */,
@@ -573,13 +602,17 @@
 				2A780CF927C76EF0007DC36A /* MyPlanetAvatarView.swift in Sources */,
 				2A441BB327C4DF110008A694 /* FollowPlanetView.swift in Sources */,
 				6A669052282BD6E6009E56E2 /* TemplateBrowserPreviewWebView.swift in Sources */,
+				2A79FB2E289819AD00F06DDF /* PlanetDownloadsItemView.swift in Sources */,
 				2AC4995D27BB758B00F1C2D1 /* Extensions.swift in Sources */,
+				2A7022F42897DF5700022F13 /* PlanetDownloadsViewController.swift in Sources */,
 				6ABAB91828215FF30014F209 /* TemplatePreviewView.swift in Sources */,
 				2A09A35C27C257D60003A0B5 /* PlanetMainView.swift in Sources */,
 				2A441BB027C4DD980008A694 /* CreatePlanetView.swift in Sources */,
 				2A2E33F227F4A93B0093F405 /* AttachmentThumbnailView.swift in Sources */,
 				2AC4997427BC0EBA00F1C2D1 /* Planet.xcdatamodeld in Sources */,
+				2A7022F02897DF3100022F13 /* PlanetDownloadsWindowController.swift in Sources */,
 				2AC4994927BB6E7500F1C2D1 /* PlanetApp.swift in Sources */,
+				2A7022ED2897DF1700022F13 /* PlanetDownloadsView.swift in Sources */,
 				2A09A35F27C2581F0003A0B5 /* PlanetSidebarView.swift in Sources */,
 				2AF1318727C7CDAF007792FE /* ArticleView.swift in Sources */,
 				2A441BAC27C40AAC0008A694 /* WriterWindow.swift in Sources */,
@@ -624,11 +657,14 @@
 				72114E3DCDF2B0618F4693D7 /* MyArticleItemView.swift in Sources */,
 				72114971F1770E3DAB910F99 /* WriterStore.swift in Sources */,
 				72114A65C35BF78B1A4B7D81 /* DraftModel.swift in Sources */,
+				2A79FB2C2898184100F06DDF /* PlanetDownloadModel.swift in Sources */,
 				721145603D528B27CC6091D1 /* WriterDragAndDrop.swift in Sources */,
 				72114D4918DAC507F6E3AF7F /* MarkdownUtils.swift in Sources */,
 				72114FE37ADE9340E448FF3E /* WriterViewModel.swift in Sources */,
+				2A7022F62897E00600022F13 /* PlanetDownloadsViewModel.swift in Sources */,
 				72114683927B9B11EFE02DD4 /* OnboardingView.swift in Sources */,
 				72114717FB02C931CE9E08E9 /* MyPlanetSidebarItem.swift in Sources */,
+				2A7022F22897DF4600022F13 /* PlanetDownloadsWindow.swift in Sources */,
 				72114AFCB4EDB617C07192BB /* FollowingPlanetSidebarItem.swift in Sources */,
 				721144941B29E9E78C05A89D /* Lifetimes.swift in Sources */,
 				721149AA66E0C018BA60DB5A /* AttachmentModel.swift in Sources */,

--- a/Planet/Downloads/PlanetDownloadModel.swift
+++ b/Planet/Downloads/PlanetDownloadModel.swift
@@ -1,0 +1,32 @@
+//
+//  PlanetDownloadModel.swift
+//  Planet
+//
+//  Created by Kai on 8/1/22.
+//
+
+import Foundation
+import WebKit
+
+
+enum PlanetDownloadItemStatus: Int {
+    case idle
+    case downloading
+    case finished
+    case paused
+    case cancelled
+}
+
+
+struct PlanetDownloadItem: Identifiable, Hashable {
+    var id: UUID
+    var created: Date
+    var download: WKDownload
+}
+
+
+extension PlanetDownloadItem {
+    func downloadItemName() -> String {
+        return download.progress.fileURL?.lastPathComponent ?? "planet.default.download"
+    }
+}

--- a/Planet/Downloads/PlanetDownloadsItemView.swift
+++ b/Planet/Downloads/PlanetDownloadsItemView.swift
@@ -1,0 +1,91 @@
+//
+//  PlanetDownloadsItemView.swift
+//  Planet
+//
+//  Created by Kai on 8/1/22.
+//
+
+import SwiftUI
+
+
+struct PlanetDownloadsItemView: View {
+    @EnvironmentObject private var downloadsViewModel: PlanetDownloadsViewModel
+
+    var item: PlanetDownloadItem
+    @State private var downloadStatus: PlanetDownloadItemStatus = .idle
+
+    var body: some View {
+        HStack {
+            if downloadStatus != .downloading {
+                VStack {
+                    HStack {
+                        Text(item.downloadItemName())
+                        Spacer()
+                    }
+                    HStack {
+                        Text(item.created.description)
+                        Spacer()
+                    }
+                    .font(.caption2)
+                }
+                Spacer()
+                Button {
+                    if downloadStatus == .cancelled {
+                        item.download.progress.resume()
+                    } else if downloadStatus == .paused {
+                        item.download.progress.resume()
+                    } else if downloadStatus == .finished {
+                        revealDownloadInFinder()
+                    } else if downloadStatus == .idle {
+                        //
+                    }
+                } label: {
+                    if downloadStatus == .cancelled || downloadStatus == .paused {
+                        Image(systemName: "play.circle.fill")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 12, height: 12)
+                    } else {
+                        Image(systemName: "magnifyingglass.circle.fill")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 12, height: 12)
+                    }
+                }
+                .buttonStyle(.plain)
+                .disabled(downloadStatus == .idle)
+            } else {
+                ProgressView(item.download.progress)
+                    .progressViewStyle(.linear)
+                Spacer()
+                Button {
+                    item.download.progress.pause()
+                } label: {
+                    Image(systemName: "pause.circle.fill")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 12, height: 12)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .frame(height: 72)
+        .onReceive(downloadsViewModel.timer) { _ in
+            if item.download.progress.isFinished {
+                downloadStatus = .finished
+            } else if item.download.progress.isPaused {
+                downloadStatus = .paused
+            } else if item.download.progress.isCancelled {
+                downloadStatus = .cancelled
+            } else {
+                downloadStatus = .downloading
+            }
+        }
+    }
+
+    private func revealDownloadInFinder() {
+        if let targetPath = item.download.progress.fileURL {
+            NSWorkspace.shared.open(targetPath)
+        }
+    }
+}

--- a/Planet/Downloads/PlanetDownloadsView.swift
+++ b/Planet/Downloads/PlanetDownloadsView.swift
@@ -17,7 +17,7 @@ struct PlanetDownloadsView: View {
 
     var body: some View {
         VStack (spacing: 0) {
-            List(downloadsViewModel.downloads.sorted(by: { $0.created < $1.created }), id: \.id, selection: $downloadsViewModel.selectedDownloadID) { item in
+            List(downloadsViewModel.downloads.sorted(by: { $0.created > $1.created }), id: \.id, selection: $downloadsViewModel.selectedDownloadID) { item in
                 PlanetDownloadsItemView(item: item)
                     .environmentObject(downloadsViewModel)
             }
@@ -31,7 +31,7 @@ struct PlanetDownloadsView: View {
                 .disabled(downloadsViewModel.downloads.count == 0)
                 .buttonStyle(.bordered)
             }
-            .padding(.horizontal, 16)
+            .padding(.horizontal, 12)
             .frame(height: 32)
             .background(Color.secondary.opacity(0.05))
         }

--- a/Planet/Downloads/PlanetDownloadsView.swift
+++ b/Planet/Downloads/PlanetDownloadsView.swift
@@ -1,0 +1,49 @@
+//
+//  PlanetDownloadsView.swift
+//  Planet
+//
+//  Created by Kai on 8/1/22.
+//
+
+import SwiftUI
+
+
+struct PlanetDownloadsView: View {
+    @StateObject private var downloadsViewModel: PlanetDownloadsViewModel
+
+    init() {
+        _downloadsViewModel = StateObject(wrappedValue: PlanetDownloadsViewModel.shared)
+    }
+
+    var body: some View {
+        VStack (spacing: 0) {
+            List(downloadsViewModel.downloads.sorted(by: { $0.created < $1.created }), id: \.id, selection: $downloadsViewModel.selectedDownloadID) { item in
+                PlanetDownloadsItemView(item: item)
+                    .environmentObject(downloadsViewModel)
+            }
+            HStack {
+                Spacer()
+                Button {
+                    downloadsViewModel.removeAllDownloads()
+                } label: {
+                    Text("Clear")
+                }
+                .disabled(downloadsViewModel.downloads.count == 0)
+                .buttonStyle(.bordered)
+            }
+            .padding(.horizontal, 16)
+            .frame(height: 32)
+            .background(Color.secondary.opacity(0.05))
+        }
+        .padding(0)
+        .frame(minWidth: 320, idealWidth: 320, maxWidth: 640, minHeight: 480, idealHeight: 480, maxHeight: .infinity)
+    }
+}
+
+
+struct PlanetDownloadsView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanetDownloadsView()
+            .frame(width: 320, height: 320)
+    }
+}

--- a/Planet/Downloads/PlanetDownloadsViewController.swift
+++ b/Planet/Downloads/PlanetDownloadsViewController.swift
@@ -1,0 +1,40 @@
+//
+//  PlanetDownloadsViewController.swift
+//  Planet
+//
+//  Created by Kai on 8/1/22.
+//
+
+import Cocoa
+import SwiftUI
+
+
+class PlanetDownloadsViewController: NSViewController {
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let contentView = NSHostingView(rootView: PlanetDownloadsView())
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(contentView)
+        contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        contentView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+    }
+
+    override func loadView() {
+        self.view = NSView()
+        view.frame.size = CGSize(width: 320, height: 480)
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+    }
+
+}

--- a/Planet/Downloads/PlanetDownloadsViewModel.swift
+++ b/Planet/Downloads/PlanetDownloadsViewModel.swift
@@ -14,15 +14,20 @@ import SwiftUI
 class PlanetDownloadsViewModel: ObservableObject {
     static let shared = PlanetDownloadsViewModel()
     
-    let timer = Timer.publish(every: 1, tolerance: 0.25, on: .current, in: .common).autoconnect()
+    let timer = Timer.publish(every: 0.5, tolerance: 0.1, on: .current, in: .common).autoconnect()
 
     @Published private(set) var downloads: [PlanetDownloadItem] = [] {
         didSet {
-            // MARK: TODO: deal with downloads history.
+            // MARK: TODO: handle downloads history.
+            saveDownloads()
         }
     }
 
     @Published var selectedDownloadID: UUID?
+
+    init() {
+        downloads = loadDownloads()
+    }
 
     func addDownload(_ download: PlanetDownloadItem) {
         if !downloads.contains(download) {
@@ -35,5 +40,12 @@ class PlanetDownloadsViewModel: ObservableObject {
             item.download.progress.cancel()
         }
         downloads.removeAll()
+    }
+
+    private func saveDownloads() {
+    }
+
+    private func loadDownloads() -> [PlanetDownloadItem] {
+        return []
     }
 }

--- a/Planet/Downloads/PlanetDownloadsViewModel.swift
+++ b/Planet/Downloads/PlanetDownloadsViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  PlanetDownloadsViewModel.swift
+//  Planet
+//
+//  Created by Kai on 8/1/22.
+//
+
+import Foundation
+import WebKit
+import SwiftUI
+
+
+@MainActor
+class PlanetDownloadsViewModel: ObservableObject {
+    static let shared = PlanetDownloadsViewModel()
+    
+    let timer = Timer.publish(every: 1, tolerance: 0.25, on: .current, in: .common).autoconnect()
+
+    @Published private(set) var downloads: [PlanetDownloadItem] = [] {
+        didSet {
+            // MARK: TODO: deal with downloads history.
+        }
+    }
+
+    @Published var selectedDownloadID: UUID?
+
+    func addDownload(_ download: PlanetDownloadItem) {
+        if !downloads.contains(download) {
+            downloads.insert(download, at: 0)
+        }
+    }
+
+    func removeAllDownloads() {
+        for item in downloads {
+            item.download.progress.cancel()
+        }
+        downloads.removeAll()
+    }
+}

--- a/Planet/Downloads/PlanetDownloadsWindow.swift
+++ b/Planet/Downloads/PlanetDownloadsWindow.swift
@@ -1,0 +1,38 @@
+//
+//  PlanetDownloadsWindow.swift
+//  Planet
+//
+//  Created by Kai on 8/1/22.
+//
+
+import Cocoa
+
+
+class PlanetDownloadsWindow: NSWindow {
+    override init(contentRect: NSRect, styleMask style: NSWindow.StyleMask, backing backingStoreType: NSWindow.BackingStoreType, defer flag: Bool) {
+        super.init(contentRect: contentRect, styleMask: [.miniaturizable, .closable, .resizable, .titled],  backing: .buffered, defer: true)
+        self.collectionBehavior = .fullScreenNone
+        self.minSize = NSMakeSize(320, 480)
+        self.maxSize = NSMakeSize(640, CGFloat.infinity)
+        self.title = "Downloads"
+        self.titlebarAppearsTransparent = false
+        self.contentViewController = PlanetDownloadsViewController()
+        self.delegate = self
+    }
+}
+
+
+extension PlanetDownloadsWindow: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        if let window = notification.object as? PlanetDownloadsWindow {
+            window.delegate = nil
+            PlanetAppDelegate.shared.downloadsWindowController = nil
+        }
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        sender.contentView = nil
+        sender.contentViewController = nil
+        return true
+    }
+}

--- a/Planet/Downloads/PlanetDownloadsWindowController.swift
+++ b/Planet/Downloads/PlanetDownloadsWindowController.swift
@@ -1,0 +1,26 @@
+//
+//  PlanetDownloadsWindowController.swift
+//  Planet
+//
+//  Created by Kai on 8/1/22.
+//
+
+import Cocoa
+
+
+class PlanetDownloadsWindowController: NSWindowController {
+    override init(window: NSWindow?) {
+        let windowSize = NSSize(width: 320, height: 480)
+        let screenSize = NSScreen.main?.frame.size ?? .zero
+        let rect = NSMakeRect(screenSize.width/2 - windowSize.width/2, screenSize.height/2 - windowSize.height/2, windowSize.width, windowSize.height)
+        let w = PlanetDownloadsWindow(contentRect: rect, styleMask: [], backing: .buffered, defer: true)
+        super.init(window: w)
+        self.window?.setFrameAutosaveName("Planet Downloads Window")
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+

--- a/Planet/Helper/URLUtils.swift
+++ b/Planet/Helper/URLUtils.swift
@@ -40,6 +40,12 @@ struct URLUtils {
         try! FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
     }()
+
+    static let downloadHistoryPath: URL = {
+        let url = repoPath.appendingPathComponent("Downloads", isDirectory: true)
+        try! FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }()
 }
 
 extension URL {

--- a/Planet/Planet.entitlements
+++ b/Planet/Planet.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
@@ -11,9 +13,9 @@
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
-    <array>
-        <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
-        <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
-    </array>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+	</array>
 </dict>
 </plist>

--- a/Planet/PlanetApp.swift
+++ b/Planet/PlanetApp.swift
@@ -10,7 +10,7 @@ import UserNotifications
 
 @main
 struct PlanetApp: App {
-    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @NSApplicationDelegateAdaptor(PlanetAppDelegate.self) var appDelegate
     @StateObject var planetStore: PlanetStore
     @StateObject var templateStore: TemplateStore
     @StateObject var updater: PlanetUpdater
@@ -41,6 +41,13 @@ struct PlanetApp: App {
                     Text("Template Browser")
                 }
                 .keyboardShortcut("l", modifiers: [.command, .shift])
+
+                Button {
+                    PlanetAppDelegate.shared.openDownloadsWindow()
+                } label: {
+                    Text("Downloads")
+                }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
 
                 Divider()
 
@@ -112,7 +119,11 @@ struct PlanetApp: App {
     }
 }
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+class PlanetAppDelegate: NSObject, NSApplicationDelegate {
+    static let shared = PlanetAppDelegate()
+
+    var downloadsWindowController: PlanetDownloadsWindowController?
+
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         true
     }
@@ -189,8 +200,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 }
 
-
-extension AppDelegate: UNUserNotificationCenterDelegate {
+extension PlanetAppDelegate: UNUserNotificationCenterDelegate {
     func setupNotification() {
         let center = UNUserNotificationCenter.current()
         center.getNotificationSettings { settings in
@@ -256,5 +266,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         processNotification(response)
         completionHandler()
+    }
+}
+
+
+extension PlanetAppDelegate {
+    func openDownloadsWindow() {
+        if downloadsWindowController == nil {
+            downloadsWindowController = PlanetDownloadsWindowController()
+        }
+        downloadsWindowController?.showWindow(nil)
     }
 }

--- a/Planet/Views/ArticleWebView.swift
+++ b/Planet/Views/ArticleWebView.swift
@@ -51,7 +51,7 @@ struct ArticleWebView: NSViewRepresentable {
 
         private func shouldHandleDownloadForMimeType(_ mimeType: String) -> Bool {
             // MARK: TODO: more mime types for download tasks.
-            let downloadableMimeTypes: [String] = ["application/pdf", "image/jpeg", "image/png"]
+            let downloadableMimeTypes: [String] = ["application/pdf", "image/jpeg", "image/png", "audio/aac", "video/x-msvideo", "application/msword", "text/csv", "application/epub+zip", "application/gzip", "image/gif", "audio/mpeg", "video/mp4", "video/mpeg", "application/vnd.apple.installer+xml", "audio/ogg", "video/ogg", "application/vnd.ms-powerpoint", "application/vnd.rar", "image/svg+xml", "application/x-tar", "image/tiff", "font/ttf", "audio/wav", "audio/webm", "video/webm", "image/webp", "application/zip", "application/x-7z-compressed"]
             return downloadableMimeTypes.contains(mimeType)
         }
 


### PR DESCRIPTION
Support basic download tasks in article web view:
- Added a downloads window
- Updated web view navigation policy for downloading file and opening link in system browser
- Fixed a navigation policy issue to handle link with target="_blank" tag

TODO:
- Remove (patch) context menu in article web view, currently options like download linked file is not working
- Add more MIME types
- Handle downloads history
- Handle failed download task