### PR TITLE
Process internal links

### DIFF
--- a/Planet.xcodeproj/project.pbxproj
+++ b/Planet.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		2AC4996C27BB99DC00F1C2D1 /* Stencil in Frameworks */ = {isa = PBXBuildFile; productRef = 2AC4996B27BB99DC00F1C2D1 /* Stencil */; };
 		2AC4997427BC0EBA00F1C2D1 /* Planet.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 2AC4997227BC0EBA00F1C2D1 /* Planet.xcdatamodeld */; };
 		2AE07DDA27C9F4EA00377651 /* ArticleWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE07DD927C9F4EA00377651 /* ArticleWebView.swift */; };
+		2AEEBF5428C0758000A0A092 /* ArticleWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AEEBF5328C0758000A0A092 /* ArticleWebViewModel.swift */; };
 		2AF1318727C7CDAF007792FE /* ArticleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF1318627C7CDAF007792FE /* ArticleView.swift */; };
 		2AF1318927C7CE8A007792FE /* TemplatePlaceholder.html in Resources */ = {isa = PBXBuildFile; fileRef = 2AF1318827C7CE8A007792FE /* TemplatePlaceholder.html */; };
 		2AF4003927F2321F005DF1A9 /* WriterTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF4003827F2321F005DF1A9 /* WriterTextView.swift */; };
@@ -139,6 +140,7 @@
 		2AC4996927BB987B00F1C2D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2AC4997327BC0EBA00F1C2D1 /* Planet.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Planet.xcdatamodel; sourceTree = "<group>"; };
 		2AE07DD927C9F4EA00377651 /* ArticleWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleWebView.swift; sourceTree = "<group>"; };
+		2AEEBF5328C0758000A0A092 /* ArticleWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleWebViewModel.swift; sourceTree = "<group>"; };
 		2AF1318627C7CDAF007792FE /* ArticleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleView.swift; sourceTree = "<group>"; };
 		2AF1318827C7CE8A007792FE /* TemplatePlaceholder.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = TemplatePlaceholder.html; sourceTree = "<group>"; };
 		2AF4003827F2321F005DF1A9 /* WriterTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterTextView.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				2A780CF827C76EF0007DC36A /* MyPlanetAvatarView.swift */,
 				2AF1318627C7CDAF007792FE /* ArticleView.swift */,
 				2AE07DD927C9F4EA00377651 /* ArticleWebView.swift */,
+				2AEEBF5328C0758000A0A092 /* ArticleWebViewModel.swift */,
 				2A441BB127C4DDDE0008A694 /* Create & Follow Planet */,
 				72114FAFE612D3D03B0CB4DA /* Components */,
 				721144D264DD084A74B49BF8 /* MyPlanetInfoView.swift */,
@@ -626,6 +629,7 @@
 				2A09A36127C2582B0003A0B5 /* ArticleListView.swift in Sources */,
 				2A780CF927C76EF0007DC36A /* MyPlanetAvatarView.swift in Sources */,
 				2A441BB327C4DF110008A694 /* FollowPlanetView.swift in Sources */,
+				2AEEBF5428C0758000A0A092 /* ArticleWebViewModel.swift in Sources */,
 				6A669052282BD6E6009E56E2 /* TemplateBrowserPreviewWebView.swift in Sources */,
 				2A79FB2E289819AD00F06DDF /* PlanetDownloadsItemView.swift in Sources */,
 				2AC4995D27BB758B00F1C2D1 /* Extensions.swift in Sources */,

--- a/Planet/Entities/PlanetStore.swift
+++ b/Planet/Entities/PlanetStore.swift
@@ -33,8 +33,20 @@ enum PlanetDetailViewType: Hashable, Equatable {
 
     let indicatorTimer = Timer.publish(every: 1.25, tolerance: 0.25, on: .current, in: .default).autoconnect()
 
-    @Published var myPlanets: [MyPlanetModel] = []
-    @Published var followingPlanets: [FollowingPlanetModel] = []
+    @Published var myPlanets: [MyPlanetModel] = [] {
+        didSet {
+            Task { @MainActor in
+                ArticleWebViewModel.shared.updateMyPlanets(myPlanets)
+            }
+        }
+    }
+    @Published var followingPlanets: [FollowingPlanetModel] = [] {
+        didSet {
+            Task { @MainActor in
+                ArticleWebViewModel.shared.updateFollowingPlanets(followingPlanets)
+            }
+        }
+    }
     @Published var selectedView: PlanetDetailViewType? {
         didSet {
             if selectedView != oldValue {

--- a/Planet/Entities/PlanetStore.swift
+++ b/Planet/Entities/PlanetStore.swift
@@ -72,6 +72,7 @@ enum PlanetDetailViewType: Hashable, Equatable {
     @Published var isCreatingPlanet = false
     @Published var isEditingPlanet = false
     @Published var isFollowingPlanet = false
+    @Published var followingPlanetLink: String = ""
     @Published var isShowingPlanetInfo = false
     @Published var isImportingPlanet = false
     @Published var isMigrating = false

--- a/Planet/Helper/URLUtils.swift
+++ b/Planet/Helper/URLUtils.swift
@@ -67,4 +67,54 @@ extension URL {
         }
         return s
     }
+
+    var isPlanetLink: Bool {
+        let components = URLComponents(url: self, resolvingAgainstBaseURL: false)
+        if components?.scheme == "planet" {
+            return true
+        }
+        return false
+    }
+
+    /*
+     - file link is not an internal link:
+        file://
+
+     - public article link:
+        https://[*]/ipns/[ipns]/[uuid]/
+
+     - public article link (2):
+        https://[*].eth.limo/[uuid]/
+
+     - TODO: support more public article links.
+
+     - local article link:
+        http://[*]:18181/ipfs/[cid]/[uuid]/
+     */
+    var isPlanetInternalLink: Bool {
+        if let _ = self.scheme, let host = self.host {
+            let uuidString = self.lastPathComponent
+            let idString = self.deletingLastPathComponent().lastPathComponent
+            let tag = self.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent
+            let cidStringCount: Int = 59
+            let ipnsStringCount: Int = 62
+            if let _ = UUID(uuidString: uuidString), idString.count >= min(cidStringCount, ipnsStringCount) {
+                if let port = self.port, tag == "ipfs" && port == IPFSDaemon.shared.gatewayPort && idString.count == cidStringCount {
+                    // localhost article link
+                    return true
+                }
+                else if tag == "ipns" && idString.count == ipnsStringCount {
+                    // (possible) public gateway article link
+                    return true
+                }
+            }
+            else if host.hasSuffix(".eth.limo") {
+                if let _ = UUID(uuidString: uuidString) {
+                    // (possible) public gateway article link (2)
+                    return true
+                }
+            }
+        }
+        return false
+    }
 }

--- a/Planet/IPFS/IPFSState.swift
+++ b/Planet/IPFS/IPFSState.swift
@@ -15,7 +15,9 @@ import os
         RunLoop.main.add(Timer(timeInterval: 30, repeats: true) { timer in
             Task {
                 await IPFSDaemon.shared.updateOnlineStatus()
-                if !self.online && !self.isBootstrapping {
+                let onlineStatus = await self.online
+                let bootstrappingStatus = await self.isBootstrapping
+                if !onlineStatus && !bootstrappingStatus {
                     await IPFSDaemon.shared.launchDaemon()
                 }
             }

--- a/Planet/Views/ArticleWebView.swift
+++ b/Planet/Views/ArticleWebView.swift
@@ -89,8 +89,12 @@ struct ArticleWebView: NSViewRepresentable {
         }
 
         private func isInternalArticleLink(_ url: URL) -> Bool {
-            // file link is not an internal link:
+            // file link is not an internal link, check for local and public gateway article links:
             /*
+             // public
+             https://www.cloudflare-ipfs.com/ipns/k51qzi5uqu5dgt38bap3uz6k0sizcscrl2khow28r2148yietg6qkok20ncsu3/57A5E55F-1162-4C05-948C-768FDEEF2C31/
+
+             // local
              http://127.0.0.1:18181/ipfs/bafybeidu5amq53cmc6mn6timcopof63dk5674gjhaguyogjuunkcykxd7e/3C473A64-4309-4CFC-BD7C-80E23C3C391D/
              */
             debugPrint("checking if it is internal url: \(url)")
@@ -99,7 +103,6 @@ struct ArticleWebView: NSViewRepresentable {
                 let cidString = url.deletingLastPathComponent().lastPathComponent
                 let ipfsTag = url.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent
                 debugPrint("scheme: \(scheme), host: \(host), port: \(port), uuid: \(uuidString), cid: \(cidString), ipfs tag: \(ipfsTag)")
-                // MARK: TODO: Should verify host as well.
                 if let _ = UUID(uuidString: uuidString), cidString.count == "bafybeigbofhj4t4uxqwd7u6lxdqve3xazrjchagwsoqtcxilpge6sexnuq".count, ipfsTag == "ipfs", port == IPFSDaemon.shared.gatewayPort {
                     debugPrint("is internal link")
                     return true

--- a/Planet/Views/ArticleWebView.swift
+++ b/Planet/Views/ArticleWebView.swift
@@ -163,9 +163,9 @@ struct ArticleWebView: NSViewRepresentable {
                 if let mime = existings.mime, let myArticle = existings.myArticle {
                     Task.detached { @MainActor in
                         PlanetStore.shared.selectedView = .myPlanet(mime)
-                        PlanetStore.shared.refreshSelectedArticles()
                         Task { @MainActor in
                             PlanetStore.shared.selectedArticle = myArticle
+                            PlanetStore.shared.refreshSelectedArticles()
                         }
                     }
                     decisionHandler(.cancel, preferences)
@@ -173,9 +173,9 @@ struct ArticleWebView: NSViewRepresentable {
                 else if let following = existings.following, let followingArticle = existings.followingArticle {
                     Task.detached { @MainActor in
                         PlanetStore.shared.selectedView = .followingPlanet(following)
-                        PlanetStore.shared.refreshSelectedArticles()
                         Task { @MainActor in
                             PlanetStore.shared.selectedArticle = followingArticle
+                            PlanetStore.shared.refreshSelectedArticles()
                         }
                     }
                     decisionHandler(.cancel, preferences)

--- a/Planet/Views/ArticleWebViewModel.swift
+++ b/Planet/Views/ArticleWebViewModel.swift
@@ -31,36 +31,86 @@ class ArticleWebViewModel: NSObject {
         if link.starts(with: "planet://") {
             link = String(link.dropFirst("planet://".count))
         }
-        debugPrint("checking planet link: \(link)")
-        debugPrint("my planets: \(myPlanets)")
-        debugPrint("following planets: \(followingPlanets)")
         var mime: MyPlanetModel?
         var following: FollowingPlanetModel?
-//        if let existingPlanet = await myPlanets.first(where: { $0.link == link }) {
-//            mime = existingPlanet
-//        }
+        if let existingPlanet = myPlanets.first(where: { $0.ipns == link }) {
+            mime = existingPlanet
+        }
         if let existingFollowingPlanet = followingPlanets.first(where: { $0.link == link }
         ) {
             following = existingFollowingPlanet
-//            await MainActor.run {
-//                PlanetStore.shared.selectedView = .followingPlanet(existing)
-//            }
-//            throw PlanetError.PlanetExistsError
         }
         return (mime, following)
     }
 
-    func checkArticleLink(_ url: URL) -> (mime: MyPlanetModel?, following: FollowingPlanetModel?, myArticle: MyArticleModel?, publicArticle: PublicArticleModel?) {
-        debugPrint("checking article link: \(link)")
-        debugPrint("my planets: \(myPlanets)")
-        debugPrint("following planets: \(followingPlanets)")
+    func checkArticleLink(_ url: URL) -> (mime: MyPlanetModel?, following: FollowingPlanetModel?, myArticle: MyArticleModel?, followingArticle: FollowingArticleModel?) {
+        let idString = url.deletingLastPathComponent().lastPathComponent
+        let uuidString = url.lastPathComponent
+        let tagString = url.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent
 
         var mime: MyPlanetModel?
         var following: FollowingPlanetModel?
         var myArticle: MyArticleModel?
-        var publicArticle: PublicArticleModel?
+        var followingArticle: FollowingArticleModel?
 
-        return (mime, following, myArticle, publicArticle)
+        if tagString == "ipns" {
+            if let existingPlanet = myPlanets.first(where: { $0.ipns == idString }) {
+                mime = existingPlanet
+            }
+            if mime != nil {
+                for myPlanet in myPlanets {
+                    if let targetArticle = myPlanet.articles.first(where: { $0.link == "/\(uuidString)/" }) {
+                        myArticle = targetArticle
+                        break
+                    }
+                }
+            }
+            if mime == nil {
+                if let existingFollowingPlanet = followingPlanets.first(where: { $0.link == idString }
+                ) {
+                    following = existingFollowingPlanet
+                }
+                if following != nil {
+                    for planet in followingPlanets {
+                        if let targetArticle = planet.articles.first(where: { $0.link == "/\(uuidString)/" }) {
+                            followingArticle = targetArticle
+                            break
+                        }
+                    }
+                }
+            }
+        }
+        else if tagString == "ipfs" {
+            if let existingPlanet = myPlanets.first(where: { $0.ipns == idString }) {
+                mime = existingPlanet
+            }
+            if mime != nil {
+                for myPlanet in myPlanets {
+                    if let targetArticle = myPlanet.articles.first(where: { $0.link == "/\(uuidString)/" }) {
+                        myArticle = targetArticle
+                        break
+                    }
+                }
+            }
+        }
+        else if let host = url.host, host.hasSuffix(".eth.limo"), uuidString != "" {
+            for myPlanet in myPlanets {
+                if let targetArticle = myPlanet.articles.first(where: { $0.link == "/\(uuidString)/" }) {
+                    myArticle = targetArticle
+                    mime = myPlanet
+                    break
+                }
+            }
+            for planet in followingPlanets {
+                if let targetArticle = planet.articles.first(where: { $0.link == "/\(uuidString)/" }) {
+                    followingArticle = targetArticle
+                    following = planet
+                    break
+                }
+            }
+        }
+
+        return (mime, following, myArticle, followingArticle)
     }
 
     deinit {

--- a/Planet/Views/ArticleWebViewModel.swift
+++ b/Planet/Views/ArticleWebViewModel.swift
@@ -1,0 +1,70 @@
+//
+//  ArticleWebViewModel.swift
+//  Planet
+//
+//  Created by Kai on 9/1/22.
+//
+
+import Foundation
+
+
+class ArticleWebViewModel: NSObject {
+    static let shared: ArticleWebViewModel = ArticleWebViewModel()
+
+    private var myPlanets: [MyPlanetModel] = []
+    private var followingPlanets: [FollowingPlanetModel] = []
+
+    private override init() {}
+
+    @MainActor
+    func updateMyPlanets(_ planets: [MyPlanetModel]) {
+        myPlanets = planets
+    }
+
+    @MainActor
+    func updateFollowingPlanets(_ planets: [FollowingPlanetModel]) {
+        followingPlanets = planets
+    }
+
+    func checkPlanetLink(_ url: URL) -> (mime: MyPlanetModel?, following: FollowingPlanetModel?) {
+        var link = url.absoluteString.trim()
+        if link.starts(with: "planet://") {
+            link = String(link.dropFirst("planet://".count))
+        }
+        debugPrint("checking planet link: \(link)")
+        debugPrint("my planets: \(myPlanets)")
+        debugPrint("following planets: \(followingPlanets)")
+        var mime: MyPlanetModel?
+        var following: FollowingPlanetModel?
+//        if let existingPlanet = await myPlanets.first(where: { $0.link == link }) {
+//            mime = existingPlanet
+//        }
+        if let existingFollowingPlanet = followingPlanets.first(where: { $0.link == link }
+        ) {
+            following = existingFollowingPlanet
+//            await MainActor.run {
+//                PlanetStore.shared.selectedView = .followingPlanet(existing)
+//            }
+//            throw PlanetError.PlanetExistsError
+        }
+        return (mime, following)
+    }
+
+    func checkArticleLink(_ url: URL) -> (mime: MyPlanetModel?, following: FollowingPlanetModel?, myArticle: MyArticleModel?, publicArticle: PublicArticleModel?) {
+        debugPrint("checking article link: \(link)")
+        debugPrint("my planets: \(myPlanets)")
+        debugPrint("following planets: \(followingPlanets)")
+
+        var mime: MyPlanetModel?
+        var following: FollowingPlanetModel?
+        var myArticle: MyArticleModel?
+        var publicArticle: PublicArticleModel?
+
+        return (mime, following, myArticle, publicArticle)
+    }
+
+    deinit {
+        myPlanets.removeAll()
+        followingPlanets.removeAll()
+    }
+}

--- a/Planet/Views/Create & Follow Planet/FollowPlanetView.swift
+++ b/Planet/Views/Create & Follow Planet/FollowPlanetView.swift
@@ -62,7 +62,7 @@ struct FollowPlanetView: View {
         }
         .frame(width: 480, alignment: .center)
         .task {
-            // Follow a new planet from internal planet links.
+            // Follow a new planet from internal planet link.
             Task { @MainActor in
                 guard self.planetStore.followingPlanetLink != "" else { return }
                 self.link = self.planetStore.followingPlanetLink


### PR DESCRIPTION
This pull request added a new view model (ArticleWebViewModel.swift, passively updated by PlanetStore) to help checking internal links, and two helper methods in URL extension to help detecting planet links or planet internal links.

For planet links, now planet redirects internally if exists or follow if absent:
- planet://*

For planet internal links, now planet redirects to the article if exists:
- http(*)://[*]:[gateway port]/ipfs/[cid]/[uuid]/
- https://[*]/ipns/[ipns]/[uuid]/
- https://[*].eth.limo/[uuid]/


