### PR TITLE
Improved auto publishing mode.

### DIFF
--- a/Planet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Planet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -203,7 +203,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/WalletConnect/Web3.swift",
       "state" : {
-        "revision" : "a628f094f8088ec72a95792de18eeea24b997462",
+        "revision" : "bdaaed96eee3a9bf7f341165f89a94288961d14c",
         "version" : "1.0.0"
       }
     }

--- a/Planet/PlanetApp.swift
+++ b/Planet/PlanetApp.swift
@@ -325,7 +325,7 @@ extension PlanetApp {
                             Button {
                                 Task { @MainActor in
                                     do {
-                                        try await self.serviceStore.publishFolder(folder)
+                                        try await self.serviceStore.publishFolder(folder, skipCIDCheck: true)
                                         let content = UNMutableNotificationContent()
                                         content.title = "Folder Published"
                                         content.subtitle = folder.url.absoluteString


### PR DESCRIPTION
- Manually publish will now ignore CID verification
- Auto publishing will consider default ttl (7200h) expiry time (and will schedule a publishing if expires)