### PR TITLE
Fix problematic data content-length

### DIFF
--- a/Planet/PlanetAPI.swift
+++ b/Planet/PlanetAPI.swift
@@ -285,11 +285,9 @@ extension PlanetAPI {
             } else {
                 let mimeType = filePath.mimeType()
                 var responseHeader: [String: String] = ["Content-Type": mimeType]
-                if let attr = try? FileManager.default.attributesOfItem(atPath: filePath), let fileSize = attr[FileAttributeKey.size] as? UInt64 {
-                    responseHeader["Content-Length"] = try? String(fileSize)
-                }
                 // MARK: TODO: handle large size data.
                 let data = try Data(contentsOf: URL(fileURLWithPath: filePath))
+                responseHeader["Content-Length"] = String(data.count)
                 return .raw(200, "OK", responseHeader, { writer in
                     try? writer.write(data)
                 })


### PR DESCRIPTION
Fixed an error in content-length which will cause data error, Chrome seems to be ok with empty content-length field.