### PR TITLE
Key Manager UI & Keychain support

### DIFF
--- a/Planet.xcodeproj/project.pbxproj
+++ b/Planet.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		2AF4006927F37C27005DF1A9 /* WriterBasic.html in Resources */ = {isa = PBXBuildFile; fileRef = 2AF4006727F37C27005DF1A9 /* WriterBasic.html */; };
 		2AF4006A27F37C27005DF1A9 /* WriterBasicPlaceholder.html in Resources */ = {isa = PBXBuildFile; fileRef = 2AF4006827F37C27005DF1A9 /* WriterBasicPlaceholder.html */; };
 		2AF9C5BC289263BC00327A8F /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF9C5BB289263BC00327A8F /* Updater.swift */; };
+		2AFB896429B7ACF3003D893E /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB896329B7ACF3003D893E /* KeychainHelper.swift */; };
 		2AFFD51B28AD760400EDB020 /* HelpLinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFFD51A28AD760400EDB020 /* HelpLinkButton.swift */; };
 		6A0624D22876BF130014DDDD /* MigrationProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0624D12876BF130014DDDD /* MigrationProgressView.swift */; };
 		6A1DA07D28B4278300C6B5A9 /* DecentralizedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1DA07C28B4278300C6B5A9 /* DecentralizedApp.swift */; };
@@ -265,6 +266,7 @@
 		2AF4006727F37C27005DF1A9 /* WriterBasic.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = WriterBasic.html; sourceTree = "<group>"; };
 		2AF4006827F37C27005DF1A9 /* WriterBasicPlaceholder.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = WriterBasicPlaceholder.html; sourceTree = "<group>"; };
 		2AF9C5BB289263BC00327A8F /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
+		2AFB896329B7ACF3003D893E /* KeychainHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		2AFFD51A28AD760400EDB020 /* HelpLinkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpLinkButton.swift; sourceTree = "<group>"; };
 		6A0624D12876BF130014DDDD /* MigrationProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationProgressView.swift; sourceTree = "<group>"; };
 		6A0FB8A427FBA3A3008E203D /* Planet v4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Planet v4.xcdatamodel"; sourceTree = "<group>"; };
@@ -546,6 +548,7 @@
 				6A8C3A6628C9361800339A86 /* DotBitKit.swift */,
 				6A4825C928F22DAC004CE2C0 /* PodcastUtils.swift */,
 				2AA797302948A1B50031E873 /* WKScriptHelper.swift */,
+				2AFB896329B7ACF3003D893E /* KeychainHelper.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -971,6 +974,7 @@
 				6A2D6B8D285141A60078F531 /* Saver.swift in Sources */,
 				72114509730D9D97178E0E82 /* IPFSState.swift in Sources */,
 				6A2F5F1328DB75F700034D55 /* Plausible.swift in Sources */,
+				2AFB896429B7ACF3003D893E /* KeychainHelper.swift in Sources */,
 				721148F88BE8ABCC52FEB501 /* IPFSDaemon.swift in Sources */,
 				7211431A5867D4CF2960EC39 /* IPFSCommand.swift in Sources */,
 				7211453BC07C2E4A588D1618 /* URLUtils.swift in Sources */,

--- a/Planet.xcodeproj/project.pbxproj
+++ b/Planet.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		2AFB896E29BA167D003D893E /* PlanetKeyManagerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB896D29BA167D003D893E /* PlanetKeyManagerWindow.swift */; };
 		2AFB897029BA17CB003D893E /* PlanetKeyManagerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB896F29BA17CB003D893E /* PlanetKeyManagerWindowController.swift */; };
 		2AFB897229BA181F003D893E /* PlanetKeyManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB897129BA181F003D893E /* PlanetKeyManagerViewController.swift */; };
+		2AFB897429BA35D6003D893E /* PlanetKeyManager+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB897329BA35D6003D893E /* PlanetKeyManager+Extension.swift */; };
+		2AFB897629BA3ED8003D893E /* PlanetKeyManagerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB897529BA3ED8003D893E /* PlanetKeyManagerModel.swift */; };
 		2AFFD51B28AD760400EDB020 /* HelpLinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFFD51A28AD760400EDB020 /* HelpLinkButton.swift */; };
 		6A0624D22876BF130014DDDD /* MigrationProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0624D12876BF130014DDDD /* MigrationProgressView.swift */; };
 		6A1DA07D28B4278300C6B5A9 /* DecentralizedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1DA07C28B4278300C6B5A9 /* DecentralizedApp.swift */; };
@@ -275,6 +277,8 @@
 		2AFB896D29BA167D003D893E /* PlanetKeyManagerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetKeyManagerWindow.swift; sourceTree = "<group>"; };
 		2AFB896F29BA17CB003D893E /* PlanetKeyManagerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetKeyManagerWindowController.swift; sourceTree = "<group>"; };
 		2AFB897129BA181F003D893E /* PlanetKeyManagerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetKeyManagerViewController.swift; sourceTree = "<group>"; };
+		2AFB897329BA35D6003D893E /* PlanetKeyManager+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlanetKeyManager+Extension.swift"; sourceTree = "<group>"; };
+		2AFB897529BA3ED8003D893E /* PlanetKeyManagerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetKeyManagerModel.swift; sourceTree = "<group>"; };
 		2AFFD51A28AD760400EDB020 /* HelpLinkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpLinkButton.swift; sourceTree = "<group>"; };
 		6A0624D12876BF130014DDDD /* MigrationProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationProgressView.swift; sourceTree = "<group>"; };
 		6A0FB8A427FBA3A3008E203D /* Planet v4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Planet v4.xcdatamodel"; sourceTree = "<group>"; };
@@ -612,6 +616,8 @@
 				2AFB896D29BA167D003D893E /* PlanetKeyManagerWindow.swift */,
 				2AFB896F29BA17CB003D893E /* PlanetKeyManagerWindowController.swift */,
 				2AFB897129BA181F003D893E /* PlanetKeyManagerViewController.swift */,
+				2AFB897329BA35D6003D893E /* PlanetKeyManager+Extension.swift */,
+				2AFB897529BA3ED8003D893E /* PlanetKeyManagerModel.swift */,
 			);
 			path = "Key Manager";
 			sourceTree = "<group>";
@@ -952,6 +958,7 @@
 				2AC4997427BC0EBA00F1C2D1 /* Planet.xcdatamodeld in Sources */,
 				2AFB896E29BA167D003D893E /* PlanetKeyManagerWindow.swift in Sources */,
 				2A7022F02897DF3100022F13 /* PlanetDownloadsWindowController.swift in Sources */,
+				2AFB897429BA35D6003D893E /* PlanetKeyManager+Extension.swift in Sources */,
 				2AC4994927BB6E7500F1C2D1 /* PlanetApp.swift in Sources */,
 				2A7022ED2897DF1700022F13 /* PlanetDownloadsView.swift in Sources */,
 				6AABC6A7291A6216009FD13F /* WalletConnectV1.swift in Sources */,
@@ -1061,6 +1068,7 @@
 				721149A15F84CEDB799EC15B /* AudioPlayer.swift in Sources */,
 				7211436A6E9CCC30D85E8E18 /* WriterAudioView.swift in Sources */,
 				6AC33B932934159A001ABBCF /* EthereumTransaction.swift in Sources */,
+				2AFB897629BA3ED8003D893E /* PlanetKeyManagerModel.swift in Sources */,
 				6A7189662947FA2D00279D77 /* WalletConnectV2QRCodeView.swift in Sources */,
 				2AA797312948A1B50031E873 /* WKScriptHelper.swift in Sources */,
 				2AFB897029BA17CB003D893E /* PlanetKeyManagerWindowController.swift in Sources */,

--- a/Planet.xcodeproj/project.pbxproj
+++ b/Planet.xcodeproj/project.pbxproj
@@ -109,7 +109,6 @@
 		6A71896B2947FD0500279D77 /* Web3ContractABI in Frameworks */ = {isa = PBXBuildFile; productRef = 6A71896A2947FD0500279D77 /* Web3ContractABI */; };
 		6A71896D2947FD0500279D77 /* Web3PromiseKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6A71896C2947FD0500279D77 /* Web3PromiseKit */; };
 		6A8C3A6728C9361800339A86 /* DotBitKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8C3A6628C9361800339A86 /* DotBitKit.swift */; };
-		6A8C3A6A28C939E800339A86 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 6A8C3A6928C939E800339A86 /* Alamofire */; };
 		6A900193296C9F3800BC088E /* MyArticleSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A900192296C9F3800BC088E /* MyArticleSettingsView.swift */; };
 		6A9C211029792464005A815E /* AVKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A9C210F29792464005A815E /* AVKit.framework */; };
 		6AABC6A7291A6216009FD13F /* WalletConnectV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AABC6A6291A6216009FD13F /* WalletConnectV1.swift */; };
@@ -122,7 +121,6 @@
 		6AB6E515291527B800F17328 /* WalletConnectPairing in Frameworks */ = {isa = PBXBuildFile; productRef = 6AB6E514291527B800F17328 /* WalletConnectPairing */; };
 		6AB6E517291527B800F17328 /* WalletConnectPush in Frameworks */ = {isa = PBXBuildFile; productRef = 6AB6E516291527B800F17328 /* WalletConnectPush */; };
 		6ABAB91828215FF30014F209 /* TemplatePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABAB91728215FF30014F209 /* TemplatePreviewView.swift */; };
-		6AC01AEC291D139C00EB6B5F /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6AC01AEB291D139C00EB6B5F /* KeychainSwift */; };
 		6AC01AEE291D258900EB6B5F /* AccountBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC01AED291D258900EB6B5F /* AccountBadgeView.swift */; };
 		6AC01AF0291ECC7E00EB6B5F /* WalletAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC01AEF291ECC7E00EB6B5F /* WalletAccountView.swift */; };
 		6AC0BC4728F0E7FD00B85F8C /* MyPlanetPodcastSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC0BC4628F0E7FD00B85F8C /* MyPlanetPodcastSettingsView.swift */; };
@@ -369,7 +367,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6AC01AEC291D139C00EB6B5F /* KeychainSwift in Frameworks */,
 				6AB6E515291527B800F17328 /* WalletConnectPairing in Frameworks */,
 				BB7FC8752898C70A00359802 /* libcmark_gfm in Frameworks */,
 				BBAE651B28987A31007E1818 /* HTMLEntities in Frameworks */,
@@ -380,7 +377,6 @@
 				6A373A4428E8263800750256 /* CodeMirror-SwiftUI in Frameworks */,
 				6AB6E511291527B800F17328 /* WalletConnectAuth in Frameworks */,
 				6A7189692947FD0500279D77 /* Web3 in Frameworks */,
-				6A8C3A6A28C939E800339A86 /* Alamofire in Frameworks */,
 				BBC831AB2836239300CE1F67 /* PlanetSiteTemplates in Frameworks */,
 				6AB6E50F291527B800F17328 /* WalletConnect in Frameworks */,
 				2A69F04727E1B53A00141DC0 /* FeedKit in Frameworks */,
@@ -844,7 +840,6 @@
 				BB99C7062847AC9F001836B2 /* Sparkle */,
 				BBAE651A28987A31007E1818 /* HTMLEntities */,
 				BB7FC8742898C70A00359802 /* libcmark_gfm */,
-				6A8C3A6928C939E800339A86 /* Alamofire */,
 				6A373A4328E8263800750256 /* CodeMirror-SwiftUI */,
 				6ADF40C329151407007A24E8 /* Starscream */,
 				6AB6E50E291527B800F17328 /* WalletConnect */,
@@ -853,7 +848,6 @@
 				6AB6E514291527B800F17328 /* WalletConnectPairing */,
 				6AB6E516291527B800F17328 /* WalletConnectPush */,
 				6AABC6A9291A62A9009FD13F /* WalletConnectSwift */,
-				6AC01AEB291D139C00EB6B5F /* KeychainSwift */,
 				6A7189682947FD0500279D77 /* Web3 */,
 				6A71896A2947FD0500279D77 /* Web3ContractABI */,
 				6A71896C2947FD0500279D77 /* Web3PromiseKit */,
@@ -896,12 +890,10 @@
 				BB99C7052847AC9F001836B2 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				BBAE651928987A31007E1818 /* XCRemoteSwiftPackageReference "swift-html-entities" */,
 				BB7FC8732898C70A00359802 /* XCRemoteSwiftPackageReference "libcmark_gfm" */,
-				6A8C3A6828C939E800339A86 /* XCRemoteSwiftPackageReference "Alamofire" */,
 				6A373A4228E8263800750256 /* XCRemoteSwiftPackageReference "CodeMirror-SwiftUI" */,
 				6ADF40C229151407007A24E8 /* XCRemoteSwiftPackageReference "Starscream" */,
 				6AB6E50D291527B800F17328 /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */,
 				6AABC6A8291A62A9009FD13F /* XCRemoteSwiftPackageReference "WalletConnectSwift" */,
-				6AC01AEA291D139C00EB6B5F /* XCRemoteSwiftPackageReference "keychain-swift" */,
 				6A7189672947FD0500279D77 /* XCRemoteSwiftPackageReference "Web3" */,
 				2AB6A93C29703825007186A7 /* XCRemoteSwiftPackageReference "swifter" */,
 			);
@@ -1326,14 +1318,6 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		6A8C3A6828C939E800339A86 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.0.0;
-			};
-		};
 		6AABC6A8291A62A9009FD13F /* XCRemoteSwiftPackageReference "WalletConnectSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/WalletConnect/WalletConnectSwift.git";
@@ -1348,14 +1332,6 @@
 			requirement = {
 				branch = main;
 				kind = branch;
-			};
-		};
-		6AC01AEA291D139C00EB6B5F /* XCRemoteSwiftPackageReference "keychain-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/evgenyneu/keychain-swift";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 20.0.0;
 			};
 		};
 		6ADF40C229151407007A24E8 /* XCRemoteSwiftPackageReference "Starscream" */ = {
@@ -1452,11 +1428,6 @@
 			package = 6A7189672947FD0500279D77 /* XCRemoteSwiftPackageReference "Web3" */;
 			productName = Web3PromiseKit;
 		};
-		6A8C3A6928C939E800339A86 /* Alamofire */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6A8C3A6828C939E800339A86 /* XCRemoteSwiftPackageReference "Alamofire" */;
-			productName = Alamofire;
-		};
 		6AABC6A9291A62A9009FD13F /* WalletConnectSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 6AABC6A8291A62A9009FD13F /* XCRemoteSwiftPackageReference "WalletConnectSwift" */;
@@ -1486,11 +1457,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6AB6E50D291527B800F17328 /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */;
 			productName = WalletConnectPush;
-		};
-		6AC01AEB291D139C00EB6B5F /* KeychainSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6AC01AEA291D139C00EB6B5F /* XCRemoteSwiftPackageReference "keychain-swift" */;
-			productName = KeychainSwift;
 		};
 		6ADF40C329151407007A24E8 /* Starscream */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Planet.xcodeproj/project.pbxproj
+++ b/Planet.xcodeproj/project.pbxproj
@@ -79,6 +79,11 @@
 		2AF4006A27F37C27005DF1A9 /* WriterBasicPlaceholder.html in Resources */ = {isa = PBXBuildFile; fileRef = 2AF4006827F37C27005DF1A9 /* WriterBasicPlaceholder.html */; };
 		2AF9C5BC289263BC00327A8F /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF9C5BB289263BC00327A8F /* Updater.swift */; };
 		2AFB896429B7ACF3003D893E /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB896329B7ACF3003D893E /* KeychainHelper.swift */; };
+		2AFB896929BA1455003D893E /* PlanetKeyManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB896829BA1455003D893E /* PlanetKeyManagerView.swift */; };
+		2AFB896C29BA1477003D893E /* PlanetKeyManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB896B29BA1477003D893E /* PlanetKeyManagerViewModel.swift */; };
+		2AFB896E29BA167D003D893E /* PlanetKeyManagerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB896D29BA167D003D893E /* PlanetKeyManagerWindow.swift */; };
+		2AFB897029BA17CB003D893E /* PlanetKeyManagerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB896F29BA17CB003D893E /* PlanetKeyManagerWindowController.swift */; };
+		2AFB897229BA181F003D893E /* PlanetKeyManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFB897129BA181F003D893E /* PlanetKeyManagerViewController.swift */; };
 		2AFFD51B28AD760400EDB020 /* HelpLinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFFD51A28AD760400EDB020 /* HelpLinkButton.swift */; };
 		6A0624D22876BF130014DDDD /* MigrationProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0624D12876BF130014DDDD /* MigrationProgressView.swift */; };
 		6A1DA07D28B4278300C6B5A9 /* DecentralizedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1DA07C28B4278300C6B5A9 /* DecentralizedApp.swift */; };
@@ -267,6 +272,11 @@
 		2AF4006827F37C27005DF1A9 /* WriterBasicPlaceholder.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = WriterBasicPlaceholder.html; sourceTree = "<group>"; };
 		2AF9C5BB289263BC00327A8F /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
 		2AFB896329B7ACF3003D893E /* KeychainHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
+		2AFB896829BA1455003D893E /* PlanetKeyManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetKeyManagerView.swift; sourceTree = "<group>"; };
+		2AFB896B29BA1477003D893E /* PlanetKeyManagerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetKeyManagerViewModel.swift; sourceTree = "<group>"; };
+		2AFB896D29BA167D003D893E /* PlanetKeyManagerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetKeyManagerWindow.swift; sourceTree = "<group>"; };
+		2AFB896F29BA17CB003D893E /* PlanetKeyManagerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetKeyManagerWindowController.swift; sourceTree = "<group>"; };
+		2AFB897129BA181F003D893E /* PlanetKeyManagerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanetKeyManagerViewController.swift; sourceTree = "<group>"; };
 		2AFFD51A28AD760400EDB020 /* HelpLinkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpLinkButton.swift; sourceTree = "<group>"; };
 		6A0624D12876BF130014DDDD /* MigrationProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationProgressView.swift; sourceTree = "<group>"; };
 		6A0FB8A427FBA3A3008E203D /* Planet v4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Planet v4.xcdatamodel"; sourceTree = "<group>"; };
@@ -504,6 +514,7 @@
 				6A2F5F0F28DB74AB00034D55 /* Integrations */,
 				2AC4995E27BB759000F1C2D1 /* Helper */,
 				2AF4003727F231F8005DF1A9 /* Writer */,
+				2AFB896A29BA145A003D893E /* Key Manager */,
 				2A09A35D27C257E40003A0B5 /* Views */,
 				2A7022EE2897DF1B00022F13 /* Downloads */,
 				2AE44EAA28CD215C00944786 /* Settings */,
@@ -595,6 +606,18 @@
 				72114341F4E465B909F76B33 /* WriterAudioView.swift */,
 			);
 			path = Writer;
+			sourceTree = "<group>";
+		};
+		2AFB896A29BA145A003D893E /* Key Manager */ = {
+			isa = PBXGroup;
+			children = (
+				2AFB896829BA1455003D893E /* PlanetKeyManagerView.swift */,
+				2AFB896B29BA1477003D893E /* PlanetKeyManagerViewModel.swift */,
+				2AFB896D29BA167D003D893E /* PlanetKeyManagerWindow.swift */,
+				2AFB896F29BA17CB003D893E /* PlanetKeyManagerWindowController.swift */,
+				2AFB897129BA181F003D893E /* PlanetKeyManagerViewController.swift */,
+			);
+			path = "Key Manager";
 			sourceTree = "<group>";
 		};
 		6A0624D02876BF020014DDDD /* Saver */ = {
@@ -935,6 +958,7 @@
 				2A441BB027C4DD980008A694 /* CreatePlanetView.swift in Sources */,
 				2A2E33F227F4A93B0093F405 /* AttachmentThumbnailView.swift in Sources */,
 				2AC4997427BC0EBA00F1C2D1 /* Planet.xcdatamodeld in Sources */,
+				2AFB896E29BA167D003D893E /* PlanetKeyManagerWindow.swift in Sources */,
 				2A7022F02897DF3100022F13 /* PlanetDownloadsWindowController.swift in Sources */,
 				2AC4994927BB6E7500F1C2D1 /* PlanetApp.swift in Sources */,
 				2A7022ED2897DF1700022F13 /* PlanetDownloadsView.swift in Sources */,
@@ -942,8 +966,10 @@
 				2AA7974929496F730031E873 /* PFDashboardInspectorViewController.swift in Sources */,
 				2A09A35F27C2581F0003A0B5 /* PlanetSidebarView.swift in Sources */,
 				2AF1318727C7CDAF007792FE /* ArticleView.swift in Sources */,
+				2AFB896C29BA1477003D893E /* PlanetKeyManagerViewModel.swift in Sources */,
 				2A441BAC27C40AAC0008A694 /* WriterWindow.swift in Sources */,
 				6A1DA07D28B4278300C6B5A9 /* DecentralizedApp.swift in Sources */,
+				2AFB897229BA181F003D893E /* PlanetKeyManagerViewController.swift in Sources */,
 				2AF4003927F2321F005DF1A9 /* WriterTextView.swift in Sources */,
 				6A6A1468282159DC009644B6 /* TemplateStore.swift in Sources */,
 				2AF9C5BC289263BC00327A8F /* Updater.swift in Sources */,
@@ -1028,6 +1054,7 @@
 				6AB6E4FB2915227600F17328 /* WalletManager.swift in Sources */,
 				2A7022F22897DF4600022F13 /* PlanetDownloadsWindow.swift in Sources */,
 				72114AFCB4EDB617C07192BB /* FollowingPlanetSidebarItem.swift in Sources */,
+				2AFB896929BA1455003D893E /* PlanetKeyManagerView.swift in Sources */,
 				6ACF1667292570AF00AE318B /* PlanetUI.swift in Sources */,
 				2AA7974429496F730031E873 /* PFDashboardWindow.swift in Sources */,
 				2A6247AE292CC5F400714BFA /* IndicatorLabelView.swift in Sources */,
@@ -1044,6 +1071,7 @@
 				6AC33B932934159A001ABBCF /* EthereumTransaction.swift in Sources */,
 				6A7189662947FA2D00279D77 /* WalletConnectV2QRCodeView.swift in Sources */,
 				2AA797312948A1B50031E873 /* WKScriptHelper.swift in Sources */,
+				2AFB897029BA17CB003D893E /* PlanetKeyManagerWindowController.swift in Sources */,
 				2AE44EB028CD223C00944786 /* PlanetSettingsViewModel.swift in Sources */,
 				2A052AC1290971E80028E88F /* ArtworkView.swift in Sources */,
 				2A2556AF293E1E7D006462D8 /* TBWindowController.swift in Sources */,

--- a/Planet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Planet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "alamofire",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire.git",
-      "state" : {
-        "revision" : "78424be314842833c04bc3bef5b72e85fff99204",
-        "version" : "5.6.4"
-      }
-    },
-    {
       "identity" : "bigint",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/attaswift/BigInt.git",
@@ -52,15 +43,6 @@
       "state" : {
         "revision" : "68493a33d862c33c9a9f67ec729b3b7df1b20ade",
         "version" : "9.1.2"
-      }
-    },
-    {
-      "identity" : "keychain-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/evgenyneu/keychain-swift",
-      "state" : {
-        "revision" : "d108a1fa6189e661f91560548ef48651ed8d93b9",
-        "version" : "20.0.0"
       }
     },
     {

--- a/Planet/Entities/MyPlanetModel.swift
+++ b/Planet/Entities/MyPlanetModel.swift
@@ -1238,6 +1238,21 @@ class MyPlanetModel: Equatable, Hashable, Identifiable, ObservableObject, Codabl
     func delete() throws {
         try FileManager.default.removeItem(at: basePath)
         // try FileManager.default.removeItem(at: publicBasePath)
+        Task(priority: .utility) {
+            do {
+                try await IPFSDaemon.shared.removeKey(name: id.uuidString)
+            } catch {
+                debugPrint("failed to remove key from planet: \(id.uuidString), error: \(error)")
+            }
+        #if DEBUG
+            do {
+                let keys = try await IPFSDaemon.shared.listKeys()
+                debugPrint("available keys: \(keys)")
+            } catch {
+                debugPrint("failed to get keys: \(error)")
+            }
+        #endif
+        }
     }
 
     func updateTrafficAnalytics() async {

--- a/Planet/Entities/MyPlanetModel.swift
+++ b/Planet/Entities/MyPlanetModel.swift
@@ -511,7 +511,7 @@ class MyPlanetModel: Equatable, Hashable, Identifiable, ObservableObject, Codabl
             throw PlanetError.IPFSError
         }
         let keyData = try Data(contentsOf: tmpKeyPath)
-        try KeychainHelper.shared.saveData(keyData, forKey: .keyPrefix + id.uuidString)
+        try KeychainHelper.shared.saveData(keyData, forKey: .keyPrefix + id.uuidString, withICloudSync: true)
         return planet
     }
 
@@ -1269,7 +1269,7 @@ class MyPlanetModel: Equatable, Hashable, Identifiable, ObservableObject, Codabl
         Task(priority: .utility) {
             do {
                 try await IPFSDaemon.shared.removeKey(name: id.uuidString)
-                try KeychainHelper.shared.delete(forKey: .keyPrefix + id.uuidString)
+                try KeychainHelper.shared.delete(forKey: .keyPrefix + id.uuidString, withICloudSync: true)
             } catch {
                 debugPrint("failed to remove key from planet: \(id.uuidString), error: \(error)")
             }

--- a/Planet/Entities/MyPlanetModel.swift
+++ b/Planet/Entities/MyPlanetModel.swift
@@ -1082,7 +1082,7 @@ class MyPlanetModel: Equatable, Hashable, Identifiable, ObservableObject, Codabl
                 try keyData.write(to: tmpKeyPath)
                 try IPFSCommand.importKey(name: id.uuidString, target: tmpKeyPath, format: "pem-pkcs8-cleartext").run()
             } else {
-                throw PlanetError.MissingKeyError
+                throw PlanetError.MissingPlanetKeyError
             }
         }
         let cid = try await IPFSDaemon.shared.addDirectory(url: publicBasePath)

--- a/Planet/Entities/PlanetStore.swift
+++ b/Planet/Entities/PlanetStore.swift
@@ -157,6 +157,14 @@ enum PlanetDetailViewType: Hashable, Equatable {
                 selectedView = .starred
             }
         }
+        
+        // Update library path monitoring
+        if URLUtils.repoPath() == URLUtils.defaultRepoPath {
+            PlanetPublishedServiceStore.shared.stopRepoPathMonitoring()
+        } else {
+            PlanetPublishedServiceStore.shared.startRepoPathMonitoring(targetURL: URLUtils.repoPath())
+        }
+        
         // Publish my planets every 30 minutes
         RunLoop.main.add(Timer(timeInterval: 1800, repeats: true) { [self] timer in
             publishMyPlanets()

--- a/Planet/Entities/PlanetStore.swift
+++ b/Planet/Entities/PlanetStore.swift
@@ -41,6 +41,11 @@ enum PlanetDetailViewType: Hashable, Equatable {
             Task(priority: .utility) {
                 PlanetAPI.shared.updateMyPlanets(planets)
             }
+            Task(priority: .utility) {
+                await MainActor.run {
+                    NotificationCenter.default.post(name: .keyManagerReloadUI, object: nil)
+                }
+            }
         }
     }
 

--- a/Planet/Helper/DotBitKit.swift
+++ b/Planet/Helper/DotBitKit.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Alamofire
 import SwiftyJSON
 
 

--- a/Planet/Helper/KeychainHelper.swift
+++ b/Planet/Helper/KeychainHelper.swift
@@ -12,12 +12,12 @@ import os
 class KeychainHelper: NSObject {
     static let shared = KeychainHelper()
     
-    func saveData(_ data: Data, forKey key: String, syncWithICloud: Bool = false) throws {
+    func saveData(_ data: Data, forKey key: String, withICloudSync sync: Bool = false) throws {
         let saveQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword as String,
             kSecAttrAccount as String: key,
             kSecValueData as String: data,
-            kSecAttrSynchronizable as String: syncWithICloud ? kCFBooleanTrue! : kCFBooleanFalse!
+            kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
         SecItemDelete(saveQuery as CFDictionary)
         let status = SecItemAdd(saveQuery as CFDictionary, nil)
@@ -26,13 +26,13 @@ class KeychainHelper: NSObject {
         }
     }
 
-    func loadData(forKey key: String, syncWithICloud: Bool = false) throws -> Data {
+    func loadData(forKey key: String, withICloudSync sync: Bool = false) throws -> Data {
         let loadQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key,
             kSecReturnData as String: kCFBooleanTrue!,
             kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecAttrSynchronizable as String: syncWithICloud ? kCFBooleanTrue! : kCFBooleanFalse!
+            kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
         var item: CFTypeRef?
         let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
@@ -45,7 +45,7 @@ class KeychainHelper: NSObject {
         return data
     }
     
-    func saveValue(_ value: String, forKey key: String, syncWithICloud: Bool = false) throws {
+    func saveValue(_ value: String, forKey key: String, withICloudSync sync: Bool = false) throws {
         guard value.count > 0, let data = value.data(using: .utf8) else {
             throw PlanetError.KeychainSavingKeyError
         }
@@ -53,7 +53,7 @@ class KeychainHelper: NSObject {
             kSecClass as String: kSecClassGenericPassword as String,
             kSecAttrAccount as String: key,
             kSecValueData as String: data,
-            kSecAttrSynchronizable as String: syncWithICloud ? kCFBooleanTrue! : kCFBooleanFalse!
+            kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
         SecItemDelete(saveQuery as CFDictionary)
         let status = SecItemAdd(saveQuery as CFDictionary, nil)
@@ -62,13 +62,13 @@ class KeychainHelper: NSObject {
         }
     }
 
-    func loadValue(forKey key: String, syncWithICloud: Bool = false) throws -> String {
+    func loadValue(forKey key: String, withICloudSync sync: Bool = false) throws -> String {
         let loadQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key,
             kSecReturnData as String: kCFBooleanTrue!,
             kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecAttrSynchronizable as String: syncWithICloud ? kCFBooleanTrue! : kCFBooleanFalse!
+            kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
         var item: CFTypeRef?
         let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
@@ -84,11 +84,11 @@ class KeychainHelper: NSObject {
         return value
     }
     
-    func delete(forKey key: String, syncWithICloud: Bool = false) throws {
+    func delete(forKey key: String, withICloudSync sync: Bool = false) throws {
         let deleteQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword as String,
             kSecAttrAccount as String: key,
-            kSecAttrSynchronizable as String: syncWithICloud ? kCFBooleanTrue! : kCFBooleanFalse!
+            kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
         let status = SecItemDelete(deleteQuery as CFDictionary)
         if status != errSecSuccess {

--- a/Planet/Helper/KeychainHelper.swift
+++ b/Planet/Helper/KeychainHelper.swift
@@ -12,13 +12,15 @@ import os
 class KeychainHelper: NSObject {
     static let shared = KeychainHelper()
     
+    // MARK: - Data
+    
     func saveData(_ data: Data, forKey key: String, withICloudSync sync: Bool = false) throws {
         let saveQuery: [String: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key,
             kSecValueData: data,
-            kSecUseDataProtectionKeychain: true,
-            kSecAttrSynchronizable: sync ? kCFBooleanTrue! : kCFBooleanFalse!
+            kSecUseDataProtectionKeychain: false,
+            kSecAttrSynchronizable: sync
         ] as [String: Any]
         Task(priority: .utility) {
             SecItemDelete(saveQuery as CFDictionary)
@@ -33,9 +35,9 @@ class KeychainHelper: NSObject {
         let loadQuery: [String: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key,
-            kSecReturnData: kCFBooleanTrue!,
+            kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne,
-            kSecAttrSynchronizable: sync ? kCFBooleanTrue! : kCFBooleanFalse!
+            kSecAttrSynchronizable: sync
         ] as [String: Any]
         var item: CFTypeRef?
         let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
@@ -48,6 +50,8 @@ class KeychainHelper: NSObject {
         return data
     }
     
+    // MARK: - String
+    
     func saveValue(_ value: String, forKey key: String, withICloudSync sync: Bool = false) throws {
         guard value.count > 0, let data = value.data(using: .utf8) else {
             throw PlanetError.KeyManagerSavingKeyError
@@ -56,8 +60,8 @@ class KeychainHelper: NSObject {
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key,
             kSecValueData: data,
-            kSecUseDataProtectionKeychain: true,
-            kSecAttrSynchronizable: sync ? kCFBooleanTrue! : kCFBooleanFalse!
+            kSecUseDataProtectionKeychain: false,
+            kSecAttrSynchronizable: sync
         ] as [String: Any]
         Task(priority: .utility) {
             SecItemDelete(saveQuery as CFDictionary)
@@ -72,9 +76,9 @@ class KeychainHelper: NSObject {
         let loadQuery: [String: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key,
-            kSecReturnData: kCFBooleanTrue!,
+            kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne,
-            kSecAttrSynchronizable: sync ? kCFBooleanTrue! : kCFBooleanFalse!
+            kSecAttrSynchronizable: sync
         ] as [String: Any]
         var item: CFTypeRef?
         let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
@@ -90,11 +94,13 @@ class KeychainHelper: NSObject {
         return value
     }
     
+    // MARK: -
+    
     func check(forKey key: String) -> Bool {
         let loadQuery: [String: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key,
-            kSecReturnData: kCFBooleanFalse!,
+            kSecReturnData: false,
             kSecMatchLimit: kSecMatchLimitOne
         ] as [String: Any]
         let status = SecItemCopyMatching(loadQuery as CFDictionary, nil)
@@ -105,7 +111,7 @@ class KeychainHelper: NSObject {
         let deleteQuery: [String: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key,
-            kSecAttrSynchronizable: sync ? kCFBooleanTrue! : kCFBooleanFalse!
+            kSecAttrSynchronizable: sync
         ] as [String: Any]
         Task(priority: .utility) {
             let status = SecItemDelete(deleteQuery as CFDictionary)
@@ -113,5 +119,68 @@ class KeychainHelper: NSObject {
                 throw PlanetError.KeyManagerDeletingKeyError
             }
         }
+    }
+    
+    func importKeyFile(forPlanetKeyName keyName: String, fileURL url: URL) throws {
+        let keyData = try Data(contentsOf: url)
+        try IPFSCommand.importKey(name: keyName, target: url, format: "pem-pkcs8-cleartext").run()
+        let key = .keyPrefix + keyName
+        try KeychainHelper.shared.saveData(keyData, forKey: key, withICloudSync: true)
+    }
+    
+    func exportKeyFile(forPlanetName planetName: String, planetKeyName keyName: String, toDirectory url: URL) throws -> URL {
+        let safePlanetName = planetName.sanitized()
+        let targetKeyPath = url.appendingPathComponent(safePlanetName).appendingPathExtension("pem")
+        if FileManager.default.fileExists(atPath: targetKeyPath.path) {
+            throw PlanetError.KeyManagerExportingKeyExistsError
+        }
+        let tmpKeyPath = URLUtils.temporaryPath.appendingPathComponent(safePlanetName).appendingPathExtension("pem")
+        defer {
+            try? FileManager.default.removeItem(at: tmpKeyPath)
+        }
+        if FileManager.default.fileExists(atPath: tmpKeyPath.path) {
+            try FileManager.default.removeItem(at: tmpKeyPath)
+        }
+        let (ret, _, _) = try IPFSCommand.exportKey(name: keyName, target: tmpKeyPath, format: "pem-pkcs8-cleartext").run()
+        if ret != 0 {
+            throw PlanetError.IPFSError
+        }
+        try FileManager.default.copyItem(at: tmpKeyPath, to: targetKeyPath)
+        return targetKeyPath
+    }
+
+    func importKeyFromKeychain(forPlanetKeyName keyName: String) throws {
+        let key = .keyPrefix + keyName
+        if check(forKey: key) {
+            let keyData = try loadData(forKey: key, withICloudSync: true)
+            let tmpKeyPath = URLUtils.temporaryPath.appendingPathComponent(keyName).appendingPathExtension("pem")
+            if FileManager.default.fileExists(atPath: tmpKeyPath.path) {
+                try? FileManager.default.removeItem(at: tmpKeyPath)
+            }
+            try keyData.write(to: tmpKeyPath)
+            defer {
+                try? FileManager.default.removeItem(at: tmpKeyPath)
+            }
+            try IPFSCommand.importKey(name: keyName, target: tmpKeyPath, format: "pem-pkcs8-cleartext").run()
+        } else {
+            throw PlanetError.MissingPlanetKeyError
+        }
+    }
+    
+    func exportKeyToKeychain(forPlanetKeyName keyName: String) throws {
+        let tmpKeyPath = URLUtils.temporaryPath.appendingPathComponent(keyName).appendingPathExtension("pem")
+        defer {
+            try? FileManager.default.removeItem(at: tmpKeyPath)
+        }
+        if FileManager.default.fileExists(atPath: tmpKeyPath.path) {
+            try FileManager.default.removeItem(at: tmpKeyPath)
+        }
+        let (ret, _, _) = try IPFSCommand.exportKey(name: keyName, target: tmpKeyPath, format: "pem-pkcs8-cleartext").run()
+        if ret != 0 {
+            throw PlanetError.IPFSError
+        }
+        let keyData = try Data(contentsOf: tmpKeyPath)
+        let key = .keyPrefix + keyName
+        try KeychainHelper.shared.saveData(keyData, forKey: key, withICloudSync: true)
     }
 }

--- a/Planet/Helper/KeychainHelper.swift
+++ b/Planet/Helper/KeychainHelper.swift
@@ -19,10 +19,12 @@ class KeychainHelper: NSObject {
             kSecValueData as String: data,
             kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
-        SecItemDelete(saveQuery as CFDictionary)
-        let status = SecItemAdd(saveQuery as CFDictionary, nil)
-        if status != errSecSuccess {
-            throw PlanetError.KeychainSavingKeyError
+        Task(priority: .utility) {
+            SecItemDelete(saveQuery as CFDictionary)
+            let status = SecItemAdd(saveQuery as CFDictionary, nil)
+            if status != errSecSuccess {
+                throw PlanetError.KeychainSavingKeyError
+            }
         }
     }
 
@@ -55,10 +57,12 @@ class KeychainHelper: NSObject {
             kSecValueData as String: data,
             kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
-        SecItemDelete(saveQuery as CFDictionary)
-        let status = SecItemAdd(saveQuery as CFDictionary, nil)
-        if status != errSecSuccess {
-            throw PlanetError.KeychainSavingKeyError
+        Task(priority: .utility) {
+            SecItemDelete(saveQuery as CFDictionary)
+            let status = SecItemAdd(saveQuery as CFDictionary, nil)
+            if status != errSecSuccess {
+                throw PlanetError.KeychainSavingKeyError
+            }
         }
     }
 
@@ -101,9 +105,11 @@ class KeychainHelper: NSObject {
             kSecAttrAccount as String: key,
             kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
-        let status = SecItemDelete(deleteQuery as CFDictionary)
-        if status != errSecSuccess {
-            throw PlanetError.KeychainDeletingKeyError
+        Task(priority: .utility) {
+            let status = SecItemDelete(deleteQuery as CFDictionary)
+            if status != errSecSuccess {
+                throw PlanetError.KeychainDeletingKeyError
+            }
         }
     }
 }

--- a/Planet/Helper/KeychainHelper.swift
+++ b/Planet/Helper/KeychainHelper.swift
@@ -12,54 +12,87 @@ import os
 class KeychainHelper: NSObject {
     static let shared = KeychainHelper()
     
-    func saveValue(_ value: String, forKey key: String) throws {
-        guard value.count > 0, let data = value.data(using: .utf8) else {
-            throw PlanetError.KeychainSaveKeyError
-        }
+    func saveData(_ data: Data, forKey key: String, syncWithICloud: Bool = false) throws {
         let saveQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword as String,
             kSecAttrAccount as String: key,
             kSecValueData as String: data,
-            kSecAttrSynchronizable as String: kCFBooleanTrue!
+            kSecAttrSynchronizable as String: syncWithICloud ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
         SecItemDelete(saveQuery as CFDictionary)
         let status = SecItemAdd(saveQuery as CFDictionary, nil)
         if status != errSecSuccess {
-            throw PlanetError.KeychainSaveKeyError
+            throw PlanetError.KeychainSavingKeyError
         }
     }
-    
-    func loadValue(forKey key: String) throws -> String {
+
+    func loadData(forKey key: String, syncWithICloud: Bool = false) throws -> Data {
         let loadQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key,
             kSecReturnData as String: kCFBooleanTrue!,
             kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecAttrSynchronizable as String: kCFBooleanTrue!
+            kSecAttrSynchronizable as String: syncWithICloud ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
         var item: CFTypeRef?
         let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
         guard status == errSecSuccess else {
-            throw PlanetError.KeychainLoadKeyError
+            throw PlanetError.KeychainLoadingKeyError
         }
         guard let data = item as? Data else {
-            throw PlanetError.KeychainLoadKeyError
+            throw PlanetError.KeychainLoadingKeyError
+        }
+        return data
+    }
+    
+    func saveValue(_ value: String, forKey key: String, syncWithICloud: Bool = false) throws {
+        guard value.count > 0, let data = value.data(using: .utf8) else {
+            throw PlanetError.KeychainSavingKeyError
+        }
+        let saveQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword as String,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrSynchronizable as String: syncWithICloud ? kCFBooleanTrue! : kCFBooleanFalse!
+        ]
+        SecItemDelete(saveQuery as CFDictionary)
+        let status = SecItemAdd(saveQuery as CFDictionary, nil)
+        if status != errSecSuccess {
+            throw PlanetError.KeychainSavingKeyError
+        }
+    }
+
+    func loadValue(forKey key: String, syncWithICloud: Bool = false) throws -> String {
+        let loadQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: kCFBooleanTrue!,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecAttrSynchronizable as String: syncWithICloud ? kCFBooleanTrue! : kCFBooleanFalse!
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
+        guard status == errSecSuccess else {
+            throw PlanetError.KeychainLoadingKeyError
+        }
+        guard let data = item as? Data else {
+            throw PlanetError.KeychainLoadingKeyError
         }
         guard let value = String(data: data, encoding: .utf8) else {
-            throw PlanetError.KeychainLoadKeyError
+            throw PlanetError.KeychainLoadingKeyError
         }
         return value
     }
     
-    func deleteValue(forKey key: String) throws {
+    func delete(forKey key: String, syncWithICloud: Bool = false) throws {
         let deleteQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword as String,
             kSecAttrAccount as String: key,
-            kSecAttrSynchronizable as String: kCFBooleanTrue!
+            kSecAttrSynchronizable as String: syncWithICloud ? kCFBooleanTrue! : kCFBooleanFalse!
         ]
         let status = SecItemDelete(deleteQuery as CFDictionary)
         if status != errSecSuccess {
-            throw PlanetError.KeychainDeleteKeyError
+            throw PlanetError.KeychainDeletingKeyError
         }
     }
 }

--- a/Planet/Helper/KeychainHelper.swift
+++ b/Planet/Helper/KeychainHelper.swift
@@ -23,7 +23,7 @@ class KeychainHelper: NSObject {
             SecItemDelete(saveQuery as CFDictionary)
             let status = SecItemAdd(saveQuery as CFDictionary, nil)
             if status != errSecSuccess {
-                throw PlanetError.KeychainSavingKeyError
+                throw PlanetError.KeyManagerSavingKeyError
             }
         }
     }
@@ -39,17 +39,17 @@ class KeychainHelper: NSObject {
         var item: CFTypeRef?
         let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
         guard status == errSecSuccess else {
-            throw PlanetError.KeychainLoadingKeyError
+            throw PlanetError.KeyManagerLoadingKeyError
         }
         guard let data = item as? Data else {
-            throw PlanetError.KeychainLoadingKeyError
+            throw PlanetError.KeyManagerLoadingKeyError
         }
         return data
     }
     
     func saveValue(_ value: String, forKey key: String, withICloudSync sync: Bool = false) throws {
         guard value.count > 0, let data = value.data(using: .utf8) else {
-            throw PlanetError.KeychainSavingKeyError
+            throw PlanetError.KeyManagerSavingKeyError
         }
         let saveQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword as String,
@@ -61,7 +61,7 @@ class KeychainHelper: NSObject {
             SecItemDelete(saveQuery as CFDictionary)
             let status = SecItemAdd(saveQuery as CFDictionary, nil)
             if status != errSecSuccess {
-                throw PlanetError.KeychainSavingKeyError
+                throw PlanetError.KeyManagerSavingKeyError
             }
         }
     }
@@ -77,13 +77,13 @@ class KeychainHelper: NSObject {
         var item: CFTypeRef?
         let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
         guard status == errSecSuccess else {
-            throw PlanetError.KeychainLoadingKeyError
+            throw PlanetError.KeyManagerLoadingKeyError
         }
         guard let data = item as? Data else {
-            throw PlanetError.KeychainLoadingKeyError
+            throw PlanetError.KeyManagerLoadingKeyError
         }
         guard let value = String(data: data, encoding: .utf8) else {
-            throw PlanetError.KeychainLoadingKeyError
+            throw PlanetError.KeyManagerLoadingKeyError
         }
         return value
     }
@@ -108,7 +108,7 @@ class KeychainHelper: NSObject {
         Task(priority: .utility) {
             let status = SecItemDelete(deleteQuery as CFDictionary)
             if status != errSecSuccess {
-                throw PlanetError.KeychainDeletingKeyError
+                throw PlanetError.KeyManagerDeletingKeyError
             }
         }
     }

--- a/Planet/Helper/KeychainHelper.swift
+++ b/Planet/Helper/KeychainHelper.swift
@@ -14,11 +14,12 @@ class KeychainHelper: NSObject {
     
     func saveData(_ data: Data, forKey key: String, withICloudSync sync: Bool = false) throws {
         let saveQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword as String,
-            kSecAttrAccount as String: key,
-            kSecValueData as String: data,
-            kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
-        ]
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecValueData: data,
+            kSecUseDataProtectionKeychain: true,
+            kSecAttrSynchronizable: sync ? kCFBooleanTrue! : kCFBooleanFalse!
+        ] as [String: Any]
         Task(priority: .utility) {
             SecItemDelete(saveQuery as CFDictionary)
             let status = SecItemAdd(saveQuery as CFDictionary, nil)
@@ -30,12 +31,12 @@ class KeychainHelper: NSObject {
 
     func loadData(forKey key: String, withICloudSync sync: Bool = false) throws -> Data {
         let loadQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: key,
-            kSecReturnData as String: kCFBooleanTrue!,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
-        ]
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecReturnData: kCFBooleanTrue!,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecAttrSynchronizable: sync ? kCFBooleanTrue! : kCFBooleanFalse!
+        ] as [String: Any]
         var item: CFTypeRef?
         let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
         guard status == errSecSuccess else {
@@ -52,11 +53,12 @@ class KeychainHelper: NSObject {
             throw PlanetError.KeyManagerSavingKeyError
         }
         let saveQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword as String,
-            kSecAttrAccount as String: key,
-            kSecValueData as String: data,
-            kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
-        ]
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecValueData: data,
+            kSecUseDataProtectionKeychain: true,
+            kSecAttrSynchronizable: sync ? kCFBooleanTrue! : kCFBooleanFalse!
+        ] as [String: Any]
         Task(priority: .utility) {
             SecItemDelete(saveQuery as CFDictionary)
             let status = SecItemAdd(saveQuery as CFDictionary, nil)
@@ -68,12 +70,12 @@ class KeychainHelper: NSObject {
 
     func loadValue(forKey key: String, withICloudSync sync: Bool = false) throws -> String {
         let loadQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: key,
-            kSecReturnData as String: kCFBooleanTrue!,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
-        ]
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecReturnData: kCFBooleanTrue!,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecAttrSynchronizable: sync ? kCFBooleanTrue! : kCFBooleanFalse!
+        ] as [String: Any]
         var item: CFTypeRef?
         let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
         guard status == errSecSuccess else {
@@ -90,21 +92,21 @@ class KeychainHelper: NSObject {
     
     func check(forKey key: String) -> Bool {
         let loadQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: key,
-            kSecReturnData as String: kCFBooleanFalse!,
-            kSecMatchLimit as String: kSecMatchLimitOne
-        ]
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecReturnData: kCFBooleanFalse!,
+            kSecMatchLimit: kSecMatchLimitOne
+        ] as [String: Any]
         let status = SecItemCopyMatching(loadQuery as CFDictionary, nil)
         return status == errSecSuccess
     }
     
     func delete(forKey key: String, withICloudSync sync: Bool = false) throws {
         let deleteQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword as String,
-            kSecAttrAccount as String: key,
-            kSecAttrSynchronizable as String: sync ? kCFBooleanTrue! : kCFBooleanFalse!
-        ]
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecAttrSynchronizable: sync ? kCFBooleanTrue! : kCFBooleanFalse!
+        ] as [String: Any]
         Task(priority: .utility) {
             let status = SecItemDelete(deleteQuery as CFDictionary)
             if status != errSecSuccess {

--- a/Planet/Helper/KeychainHelper.swift
+++ b/Planet/Helper/KeychainHelper.swift
@@ -1,0 +1,65 @@
+//
+//  KeychainHelper.swift
+//  Planet
+//
+//  Created by Kai on 3/8/23.
+//
+
+import Foundation
+import os
+
+
+class KeychainHelper: NSObject {
+    static let shared = KeychainHelper()
+    
+    func saveValue(_ value: String, forKey key: String) throws {
+        guard value.count > 0, let data = value.data(using: .utf8) else {
+            throw PlanetError.KeychainSaveKeyError
+        }
+        let saveQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword as String,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrSynchronizable as String: kCFBooleanTrue!
+        ]
+        SecItemDelete(saveQuery as CFDictionary)
+        let status = SecItemAdd(saveQuery as CFDictionary, nil)
+        if status != errSecSuccess {
+            throw PlanetError.KeychainSaveKeyError
+        }
+    }
+    
+    func loadValue(forKey key: String) throws -> String {
+        let loadQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: kCFBooleanTrue!,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecAttrSynchronizable as String: kCFBooleanTrue!
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(loadQuery as CFDictionary, &item)
+        guard status == errSecSuccess else {
+            throw PlanetError.KeychainLoadKeyError
+        }
+        guard let data = item as? Data else {
+            throw PlanetError.KeychainLoadKeyError
+        }
+        guard let value = String(data: data, encoding: .utf8) else {
+            throw PlanetError.KeychainLoadKeyError
+        }
+        return value
+    }
+    
+    func deleteValue(forKey key: String) throws {
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword as String,
+            kSecAttrAccount as String: key,
+            kSecAttrSynchronizable as String: kCFBooleanTrue!
+        ]
+        let status = SecItemDelete(deleteQuery as CFDictionary)
+        if status != errSecSuccess {
+            throw PlanetError.KeychainDeleteKeyError
+        }
+    }
+}

--- a/Planet/Helper/KeychainHelper.swift
+++ b/Planet/Helper/KeychainHelper.swift
@@ -84,6 +84,17 @@ class KeychainHelper: NSObject {
         return value
     }
     
+    func check(forKey key: String) -> Bool {
+        let loadQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: kCFBooleanFalse!,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        let status = SecItemCopyMatching(loadQuery as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+    
     func delete(forKey key: String, withICloudSync sync: Bool = false) throws {
         let deleteQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword as String,

--- a/Planet/Helper/URLUtils.swift
+++ b/Planet/Helper/URLUtils.swift
@@ -50,6 +50,7 @@ struct URLUtils {
                             UserDefaults.standard.set(updatedBookmarkData, forKey: bookmarkKey)
                         }
                         if url.startAccessingSecurityScopedResource() {
+                            // MARK: Add repo path monitoring
                             return planetURL
                         } else {
                             UserDefaults.standard.removeObject(forKey: .settingsLibraryLocation)
@@ -64,6 +65,7 @@ struct URLUtils {
                 UserDefaults.standard.removeObject(forKey: .settingsLibraryLocation)
             }
         }
+        // MARK: Remove repo path monitoring
         return Self.defaultRepoPath
     }
     

--- a/Planet/Helper/URLUtils.swift
+++ b/Planet/Helper/URLUtils.swift
@@ -50,7 +50,6 @@ struct URLUtils {
                             UserDefaults.standard.set(updatedBookmarkData, forKey: bookmarkKey)
                         }
                         if url.startAccessingSecurityScopedResource() {
-                            // MARK: Add repo path monitoring
                             return planetURL
                         } else {
                             UserDefaults.standard.removeObject(forKey: .settingsLibraryLocation)
@@ -65,7 +64,6 @@ struct URLUtils {
                 UserDefaults.standard.removeObject(forKey: .settingsLibraryLocation)
             }
         }
-        // MARK: Remove repo path monitoring
         return Self.defaultRepoPath
     }
     

--- a/Planet/IPFS/IPFSCommand.swift
+++ b/Planet/IPFS/IPFSCommand.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+
 struct IPFSCommand {
     // executables are under <project_root>/Planet/IPFS/go-ipfs-executables
     // version: 0.16.0, last updated 2022-10-04
@@ -183,12 +184,20 @@ struct IPFSCommand {
         IPFSCommand(arguments: ["add", file.path, "--cid-version=1", "--only-hash"])
     }
 
-    static func exportKey(name: String, target: URL) -> IPFSCommand {
-        IPFSCommand(arguments: ["key", "export", name, "-o", target.path])
+    static func exportKey(name: String, target: URL, format: String = "") -> IPFSCommand {
+        var arguments: [String] = ["key", "export", name, "-o", target.path]
+        if format != "" {
+            arguments.append("--format=\(format)")
+        }
+        return IPFSCommand(arguments: arguments)
     }
 
-    static func importKey(name: String, target: URL) -> IPFSCommand {
-        IPFSCommand(arguments: ["key", "import", name, target.path])
+    static func importKey(name: String, target: URL, format: String = "") -> IPFSCommand {
+        var arguments: [String] = ["key", "import", name, target.path]
+        if format != "" {
+            arguments.append("--format=\(format)")
+        }
+        return IPFSCommand(arguments: arguments)
     }
 
     // NOTE: IPFS CLI calls internal HTTP API to communicate

--- a/Planet/IPFS/IPFSDaemon.swift
+++ b/Planet/IPFS/IPFSDaemon.swift
@@ -194,6 +194,11 @@ actor IPFSDaemon {
                         Task.detached(priority: .utility) { @MainActor in
                             NotificationCenter.default.post(name: .dashboardWebViewGoHome, object: nil)
                         }
+                        // refresh key manager
+                        Task.detached(priority: .utility) { @MainActor in
+                            NotificationCenter.default.post(name: .keyManagerReloadUI, object: nil)
+                        }
+
                         // let onboarding = UserDefaults.standard.string(forKey: "PlanetOnboarding")
                         // if onboarding == nil {
                         //     Task { @MainActor in

--- a/Planet/IPFS/IPFSDaemon.swift
+++ b/Planet/IPFS/IPFSDaemon.swift
@@ -353,13 +353,25 @@ actor IPFSDaemon {
         if ret == 0 {
             if let output = String(data: out, encoding: .utf8)?.trimmingCharacters(in: .whitespaces) {
                 let keyList = output.components(separatedBy: .newlines)
-                Self.logger.error("IPFS keypairs: \(String(describing: keyList))")
                 return keyList.contains(name)
             } else {
                 Self.logger.error("Failed to parse list IPFS keypairs: \(String(describing: out))")
             }
         }
         return false
+    }
+    
+    func listKeys() throws -> [String] {
+        Self.logger.info("List IPFS keypairs")
+        let (ret, out, _) = try IPFSCommand.listKeys().run()
+        if ret == 0 {
+            if let output = String(data: out, encoding: .utf8)?.trimmingCharacters(in: .whitespaces) {
+                return output.components(separatedBy: .newlines).filter({ $0 != "" && $0 != "self" })
+            } else {
+                Self.logger.error("Failed to parse list IPFS keypairs: \(String(describing: out))")
+            }
+        }
+        return []
     }
 
     func addDirectory(url: URL) throws -> String {

--- a/Planet/Key Manager/PlanetKeyManager+Extension.swift
+++ b/Planet/Key Manager/PlanetKeyManager+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  PlanetKeyManager+Extension.swift
+//  Planet
+//
+//  Created by Kai on 3/9/23.
+//
+
+import Foundation
+import Cocoa
+
+
+extension NSToolbar.Identifier {
+    static let keyManagerToolbarIdentifier = NSToolbar.Identifier("PlanetKeyManagerWindowToolbar")
+}
+
+
+extension NSToolbarItem.Identifier {
+    static let keyManagerReloadItem = NSToolbarItem.Identifier("PlanetKeyManagerToolbarReloadItem")
+    static let keyManagerSyncItem = NSToolbarItem.Identifier("PlanetKeyManagerToolbarSyncItem")
+    static let keyManagerImportItem = NSToolbarItem.Identifier("PlanetKeyManagerToolbarImportItem")
+    static let keyManagerExportItem = NSToolbarItem.Identifier("PlanetKeyManagerToolbarExportItem")
+}

--- a/Planet/Key Manager/PlanetKeyManager+Extension.swift
+++ b/Planet/Key Manager/PlanetKeyManager+Extension.swift
@@ -20,3 +20,13 @@ extension NSToolbarItem.Identifier {
     static let keyManagerImportItem = NSToolbarItem.Identifier("PlanetKeyManagerToolbarImportItem")
     static let keyManagerExportItem = NSToolbarItem.Identifier("PlanetKeyManagerToolbarExportItem")
 }
+
+
+extension Notification.Name {
+    static let keyManagerReloadUI = Notification.Name("PlanetKeyManagerReloadUINotification")
+}
+
+
+extension String {
+    static let keyPrefix = "PLANETKEY-"
+}

--- a/Planet/Key Manager/PlanetKeyManagerModel.swift
+++ b/Planet/Key Manager/PlanetKeyManagerModel.swift
@@ -1,0 +1,19 @@
+//
+//  PlanetKeyManagerModel.swift
+//  Planet
+//
+//  Created by Kai on 3/10/23.
+//
+
+import Foundation
+
+
+struct PlanetKeyItem: Identifiable {
+    let id: UUID
+    let planetID: UUID
+    let planetName: String
+    let keyName: String
+    let keyID: String
+    let created: Date
+    let modified: Date
+}

--- a/Planet/Key Manager/PlanetKeyManagerView.swift
+++ b/Planet/Key Manager/PlanetKeyManagerView.swift
@@ -1,0 +1,30 @@
+//
+//  PlanetKeyManagerView.swift
+//  Planet
+//
+//  Created by Kai on 3/9/23.
+//
+
+import SwiftUI
+
+
+struct PlanetKeyManagerView: View {
+    @StateObject private var keyManagerViewModel: PlanetKeyManagerViewModel
+    
+    init() {
+        _keyManagerViewModel = StateObject(wrappedValue: PlanetKeyManagerViewModel.shared)
+    }
+
+    var body: some View {
+        VStack {
+            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        }
+        .frame(minWidth: 320, idealWidth: 320, maxWidth: 640, minHeight: 480, idealHeight: 480, maxHeight: .infinity)
+    }
+}
+
+struct PlanetKeyManagerView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanetKeyManagerView()
+    }
+}

--- a/Planet/Key Manager/PlanetKeyManagerView.swift
+++ b/Planet/Key Manager/PlanetKeyManagerView.swift
@@ -24,10 +24,15 @@ struct PlanetKeyManagerView: View {
                 contentView()
             }
         }
-        .frame(minWidth: 320, idealWidth: 320, maxWidth: .infinity, minHeight: 480, idealHeight: 480, maxHeight: .infinity)
+        .frame(minWidth: 480, idealWidth: 480, maxWidth: .infinity, minHeight: 320, idealHeight: 320, maxHeight: .infinity)
         .padding(0)
         .task {
-            await keyManagerViewModel.reloadPlanetKeys()
+            await self.keyManagerViewModel.reloadPlanetKeys()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .keyManagerReloadUI)) { _ in
+            Task { @MainActor in
+                await self.keyManagerViewModel.reloadPlanetKeys()
+            }
         }
     }
     
@@ -43,11 +48,20 @@ struct PlanetKeyManagerView: View {
             TableColumn("Planet", value: \.planetName)
             TableColumn("Key Name", value: \.keyName)
             TableColumn("Key ID", value: \.keyID)
+            TableColumn("Keystore Status") { item in
+                if keyManagerViewModel.keysInKeystore.contains(item.keyName) {
+                    Label("In Keystore", systemImage: "checkmark.circle")
+                } else {
+                    Label("Not in Keystore", systemImage: "poweroff")
+                }
+            }
             TableColumn("Keychain Status") { item in
-                if KeychainHelper.shared.check(forKey: item.keyName) {
+                if KeychainHelper.shared.check(forKey: .keyPrefix + item.keyName) {
                     Label("In Keychain", systemImage: "checkmark.circle")
+                        .foregroundColor(.green)
                 } else {
                     Label("Not in Keychain", systemImage: "poweroff")
+                        .foregroundColor(.secondary)
                 }
             }
         }

--- a/Planet/Key Manager/PlanetKeyManagerView.swift
+++ b/Planet/Key Manager/PlanetKeyManagerView.swift
@@ -17,9 +17,40 @@ struct PlanetKeyManagerView: View {
 
     var body: some View {
         VStack {
-            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+            switch keyManagerViewModel.refreshing {
+            case true:
+                loadingView()
+            case false:
+                contentView()
+            }
         }
-        .frame(minWidth: 320, idealWidth: 320, maxWidth: 640, minHeight: 480, idealHeight: 480, maxHeight: .infinity)
+        .frame(minWidth: 320, idealWidth: 320, maxWidth: .infinity, minHeight: 480, idealHeight: 480, maxHeight: .infinity)
+        .padding(0)
+        .task {
+            await keyManagerViewModel.reloadPlanetKeys()
+        }
+    }
+    
+    @ViewBuilder
+    private func loadingView() -> some View {
+        Text("Reloading...")
+            .foregroundColor(.secondary)
+    }
+    
+    @ViewBuilder
+    private func contentView() -> some View {
+        Table(keyManagerViewModel.keys, selection: $keyManagerViewModel.selectedKeyItemID) {
+            TableColumn("Planet", value: \.planetName)
+            TableColumn("Key Name", value: \.keyName)
+            TableColumn("Key ID", value: \.keyID)
+            TableColumn("Keychain Status") { item in
+                if KeychainHelper.shared.check(forKey: item.keyName) {
+                    Label("In Keychain", systemImage: "checkmark.circle")
+                } else {
+                    Label("Not in Keychain", systemImage: "poweroff")
+                }
+            }
+        }
     }
 }
 

--- a/Planet/Key Manager/PlanetKeyManagerViewController.swift
+++ b/Planet/Key Manager/PlanetKeyManagerViewController.swift
@@ -1,0 +1,41 @@
+//
+//  PlanetKeyManagerViewController.swift
+//  Planet
+//
+//  Created by Kai on 3/9/23.
+//
+
+import Foundation
+import Cocoa
+import SwiftUI
+
+
+class PlanetKeyManagerViewController: NSViewController {
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let contentView = NSHostingView(rootView: PlanetKeyManagerView())
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(contentView)
+        contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        contentView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+    }
+
+    override func loadView() {
+        self.view = NSView()
+        view.frame.size = CGSize(width: 320, height: 480)
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+    }
+
+}

--- a/Planet/Key Manager/PlanetKeyManagerViewModel.swift
+++ b/Planet/Key Manager/PlanetKeyManagerViewModel.swift
@@ -38,19 +38,9 @@ class PlanetKeyManagerViewModel: ObservableObject {
         }
         var items: [PlanetKeyItem] = []
         let planets = PlanetStore.shared.myPlanets
-        do {
-            let allKeys = try await IPFSDaemon.shared.listKeys()
-            for key in allKeys {
-                for planet in planets {
-                    if planet.id.uuidString == key {
-                        let item = PlanetKeyItem(id: UUID(), planetID: planet.id, planetName: planet.name, keyName: planet.id.uuidString, keyID: planet.ipns, created: planet.created, modified: planet.created)
-                        items.append(item)
-                        break
-                    }
-                }
-            }
-        } catch {
-            debugPrint("failed to prepare planet keys, error: \(error)")
+        for planet in planets {
+            let item = PlanetKeyItem(id: UUID(), planetID: planet.id, planetName: planet.name, keyName: planet.id.uuidString, keyID: planet.ipns, created: planet.created, modified: planet.created)
+            items.append(item)
         }
         self.keys = items.sorted(by: { a, b in
             return a.created > b.created

--- a/Planet/Key Manager/PlanetKeyManagerViewModel.swift
+++ b/Planet/Key Manager/PlanetKeyManagerViewModel.swift
@@ -11,4 +11,35 @@ import SwiftUI
 
 class PlanetKeyManagerViewModel: ObservableObject {
     static let shared = PlanetKeyManagerViewModel()
+    
+    @Published var refreshing: Bool = false
+    @Published var selectedKeyItemID: UUID?
+    @Published private(set) var keys: [PlanetKeyItem] = []
+    
+    @MainActor
+    func reloadPlanetKeys() async {
+        refreshing = true
+        defer {
+            refreshing = false
+        }
+        var items: [PlanetKeyItem] = []
+        let planets = PlanetStore.shared.myPlanets
+        do {
+            let allKeys = try await IPFSDaemon.shared.listKeys()
+            for key in allKeys {
+                for planet in planets {
+                    if planet.id.uuidString == key {
+                        let item = PlanetKeyItem(id: UUID(), planetID: planet.id, planetName: planet.name, keyName: planet.id.uuidString, keyID: planet.ipns, created: planet.created, modified: planet.created)
+                        items.append(item)
+                        break
+                    }
+                }
+            }
+        } catch {
+            debugPrint("failed to prepare planet keys, error: \(error)")
+        }
+        self.keys = items.sorted(by: { a, b in
+            return a.created > b.created
+        })
+    }
 }

--- a/Planet/Key Manager/PlanetKeyManagerViewModel.swift
+++ b/Planet/Key Manager/PlanetKeyManagerViewModel.swift
@@ -31,6 +31,7 @@ class PlanetKeyManagerViewModel: ObservableObject {
     
     @MainActor
     func reloadPlanetKeys() async {
+        selectedKeyItemID = nil
         refreshing = true
         defer {
             refreshing = false

--- a/Planet/Key Manager/PlanetKeyManagerViewModel.swift
+++ b/Planet/Key Manager/PlanetKeyManagerViewModel.swift
@@ -1,0 +1,14 @@
+//
+//  PlanetKeyManagerViewModel.swift
+//  Planet
+//
+//  Created by Kai on 3/9/23.
+//
+
+import Foundation
+import SwiftUI
+
+
+class PlanetKeyManagerViewModel: ObservableObject {
+    static let shared = PlanetKeyManagerViewModel()
+}

--- a/Planet/Key Manager/PlanetKeyManagerWindow.swift
+++ b/Planet/Key Manager/PlanetKeyManagerWindow.swift
@@ -13,7 +13,7 @@ class PlanetKeyManagerWindow: NSWindow {
     override init(contentRect: NSRect, styleMask style: NSWindow.StyleMask, backing backingStoreType: NSWindow.BackingStoreType, defer flag: Bool) {
         super.init(contentRect: contentRect, styleMask: [.miniaturizable, .closable, .resizable, .titled],  backing: .buffered, defer: true)
         self.collectionBehavior = .fullScreenNone
-        self.minSize = NSMakeSize(320, 480)
+        self.minSize = NSMakeSize(480, 320)
         self.maxSize = NSMakeSize(CGFloat.infinity, CGFloat.infinity)
         self.title = "Key Manager"
         self.titlebarAppearsTransparent = false

--- a/Planet/Key Manager/PlanetKeyManagerWindow.swift
+++ b/Planet/Key Manager/PlanetKeyManagerWindow.swift
@@ -14,7 +14,7 @@ class PlanetKeyManagerWindow: NSWindow {
         super.init(contentRect: contentRect, styleMask: [.miniaturizable, .closable, .resizable, .titled],  backing: .buffered, defer: true)
         self.collectionBehavior = .fullScreenNone
         self.minSize = NSMakeSize(320, 480)
-        self.maxSize = NSMakeSize(640, CGFloat.infinity)
+        self.maxSize = NSMakeSize(CGFloat.infinity, CGFloat.infinity)
         self.title = "Key Manager"
         self.titlebarAppearsTransparent = false
         self.contentViewController = PlanetKeyManagerViewController()

--- a/Planet/Key Manager/PlanetKeyManagerWindow.swift
+++ b/Planet/Key Manager/PlanetKeyManagerWindow.swift
@@ -1,0 +1,34 @@
+//
+//  PlanetKeyManagerWindow.swift
+//  Planet
+//
+//  Created by Kai on 3/9/23.
+//
+
+import Foundation
+import Cocoa
+
+
+class PlanetKeyManagerWindow: NSWindow {
+    override init(contentRect: NSRect, styleMask style: NSWindow.StyleMask, backing backingStoreType: NSWindow.BackingStoreType, defer flag: Bool) {
+        super.init(contentRect: contentRect, styleMask: [.miniaturizable, .closable, .resizable, .titled],  backing: .buffered, defer: true)
+        self.collectionBehavior = .fullScreenNone
+        self.minSize = NSMakeSize(320, 480)
+        self.maxSize = NSMakeSize(640, CGFloat.infinity)
+        self.title = "Key Manager"
+        self.titlebarAppearsTransparent = false
+        self.contentViewController = PlanetKeyManagerViewController()
+        self.delegate = self
+    }
+}
+
+
+extension PlanetKeyManagerWindow: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        
+    }
+    
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        return true
+    }
+}

--- a/Planet/Key Manager/PlanetKeyManagerWindowController.swift
+++ b/Planet/Key Manager/PlanetKeyManagerWindowController.swift
@@ -16,10 +16,172 @@ class PlanetKeyManagerWindowController: NSWindowController {
         let rect = NSMakeRect(screenSize.width/2 - windowSize.width/2, screenSize.height/2 - windowSize.height/2, windowSize.width, windowSize.height)
         let w = PlanetKeyManagerWindow(contentRect: rect, styleMask: [], backing: .buffered, defer: true)
         super.init(window: w)
+        self.setupToolbar()
         self.window?.setFrameAutosaveName("Planet Key Manager Window")
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func windowDidLoad() {
+        super.windowDidLoad()
+    }
+    
+    private func setupToolbar() {
+        guard let w = self.window else { return }
+        let toolbar = NSToolbar(identifier: .keyManagerToolbarIdentifier)
+        toolbar.delegate = self
+        toolbar.allowsUserCustomization = false
+        toolbar.autosavesConfiguration = true
+        toolbar.displayMode = .iconOnly
+        w.title = "Key Manager"
+        w.toolbar = toolbar
+        w.toolbar?.validateVisibleItems()
+    }
+    
+    private func reloadPlanetKeys() {
+        Task { @MainActor in
+            await PlanetKeyManagerViewModel.shared.reloadPlanetKeys()
+        }
+    }
+    
+    private func syncForSelectedKeyItem() {
+        let viewModel = PlanetKeyManagerViewModel.shared
+        guard let selectedKeyItemID = viewModel.selectedKeyItemID, let keyItem = viewModel.keys.first(where: { $0.id == selectedKeyItemID }) else { return }
+        // MARK: TODO: sync into keychain
+    }
+    
+    private func importForSelectedKeyItem() {
+        debugPrint("import item")
+    }
+    
+    private func exportForSelectedKeyItem() {
+        debugPrint("export item")
+    }
+    
+    @objc private func toolbarItemAction(_ sender: Any) {
+        guard let item = sender as? NSToolbarItem else { return }
+        switch item.itemIdentifier {
+        case .keyManagerReloadItem:
+            reloadPlanetKeys()
+        case .keyManagerImportItem:
+            importForSelectedKeyItem()
+        case .keyManagerExportItem:
+            exportForSelectedKeyItem()
+        case .keyManagerSyncItem:
+            syncForSelectedKeyItem()
+        default:
+            break
+        }
+    }
+}
+
+
+// MARK: - Toolbar Validation
+
+extension PlanetKeyManagerWindowController: NSToolbarItemValidation {
+    func validateToolbarItem(_ item: NSToolbarItem) -> Bool {
+        switch item.itemIdentifier {
+        case .keyManagerReloadItem:
+            return true
+        case .keyManagerSyncItem, .keyManagerImportItem, .keyManagerExportItem:
+            return PlanetKeyManagerViewModel.shared.selectedKeyItemID != nil
+        default:
+            return false
+        }
+    }
+}
+
+
+// MARK: - Toolbar Delegate
+
+extension PlanetKeyManagerWindowController: NSToolbarDelegate {
+    func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
+        switch itemIdentifier {
+        case .keyManagerReloadItem:
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.target = self
+            item.action = #selector(self.toolbarItemAction(_:))
+            item.label = "Reload"
+            item.paletteLabel = "Reload Planet Keys"
+            item.toolTip = "Reload Planet Keys"
+            item.isBordered = true
+            item.image = NSImage(systemSymbolName: "arrow.clockwise", accessibilityDescription: "Reload Planet Keys")
+            return item
+        case .keyManagerSyncItem:
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.target = self
+            item.action = #selector(self.toolbarItemAction(_:))
+            item.label = "Sync"
+            item.paletteLabel = "Sync to Keychain"
+            item.toolTip = "Sync to Keychain"
+            item.isBordered = true
+            item.image = NSImage(systemSymbolName: "key", accessibilityDescription: "Sync to Keychain")
+            return item
+        case .keyManagerImportItem:
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.target = self
+            item.action = #selector(self.toolbarItemAction(_:))
+            item.label = "Import"
+            item.paletteLabel = "Import Planet Key"
+            item.toolTip = "Import Planet Key"
+            item.isBordered = true
+            item.image = NSImage(systemSymbolName: "square.and.arrow.down", accessibilityDescription: "Import Planet Key")
+            return item
+        case .keyManagerExportItem:
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.target = self
+            item.action = #selector(self.toolbarItemAction(_:))
+            item.label = "Export"
+            item.paletteLabel = "Export Planet Key"
+            item.toolTip = "Export Planet Key"
+            item.isBordered = true
+            item.image = NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: "Export Planet Key")
+            return item
+        default:
+            return nil
+        }
+    }
+    
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        return [
+            .flexibleSpace,
+            .keyManagerSyncItem,
+            .keyManagerImportItem,
+            .keyManagerExportItem,
+            .keyManagerReloadItem
+        ]
+    }
+    
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        return [
+            .flexibleSpace,
+            .keyManagerSyncItem,
+            .keyManagerImportItem,
+            .keyManagerExportItem,
+            .keyManagerReloadItem
+        ]
+    }
+    
+    func toolbarImmovableItemIdentifiers(_ toolbar: NSToolbar) -> Set<NSToolbarItem.Identifier> {
+        return [
+            .flexibleSpace,
+            .keyManagerSyncItem,
+            .keyManagerImportItem,
+            .keyManagerExportItem,
+            .keyManagerReloadItem
+        ]
+    }
+
+    func toolbarWillAddItem(_ notification: Notification) {
+    }
+
+    func toolbarDidRemoveItem(_ notification: Notification) {
+        setupToolbar()
+    }
+
+    func toolbarSelectableItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        return []
     }
 }

--- a/Planet/Key Manager/PlanetKeyManagerWindowController.swift
+++ b/Planet/Key Manager/PlanetKeyManagerWindowController.swift
@@ -157,8 +157,25 @@ extension PlanetKeyManagerWindowController: NSToolbarItemValidation {
         switch item.itemIdentifier {
         case .keyManagerReloadItem:
             return true
-        case .keyManagerSyncItem, .keyManagerImportItem, .keyManagerExportItem:
-            return PlanetKeyManagerViewModel.shared.selectedKeyItemID != nil
+        case .keyManagerSyncItem:
+            if let selectedKeyItemID = PlanetKeyManagerViewModel.shared.selectedKeyItemID, let keyItem = PlanetKeyManagerViewModel.shared.keys.first(where: { $0.id == selectedKeyItemID }) {
+                let keychainExists: Bool = KeychainHelper.shared.check(forKey: .keyPrefix + keyItem.keyName)
+                let keystoreExists: Bool = PlanetKeyManagerViewModel.shared.keysInKeystore.contains(keyItem.keyName)
+                return !keychainExists || !keystoreExists
+            }
+            return false
+        case .keyManagerImportItem:
+            if let selectedKeyItemID = PlanetKeyManagerViewModel.shared.selectedKeyItemID, let keyItem = PlanetKeyManagerViewModel.shared.keys.first(where: { $0.id == selectedKeyItemID }) {
+                let keystoreExists: Bool = PlanetKeyManagerViewModel.shared.keysInKeystore.contains(keyItem.keyName)
+                return !keystoreExists
+            }
+            return false
+        case .keyManagerExportItem:
+            if let selectedKeyItemID = PlanetKeyManagerViewModel.shared.selectedKeyItemID, let keyItem = PlanetKeyManagerViewModel.shared.keys.first(where: { $0.id == selectedKeyItemID }) {
+                let keystoreExists: Bool = PlanetKeyManagerViewModel.shared.keysInKeystore.contains(keyItem.keyName)
+                return keystoreExists
+            }
+            return false
         default:
             return false
         }

--- a/Planet/Key Manager/PlanetKeyManagerWindowController.swift
+++ b/Planet/Key Manager/PlanetKeyManagerWindowController.swift
@@ -1,0 +1,25 @@
+//
+//  PlanetKeyManagerWindowController.swift
+//  Planet
+//
+//  Created by Kai on 3/9/23.
+//
+
+import Foundation
+import Cocoa
+
+
+class PlanetKeyManagerWindowController: NSWindowController {
+    override init(window: NSWindow?) {
+        let windowSize = NSSize(width: 320, height: 480)
+        let screenSize = NSScreen.main?.frame.size ?? .zero
+        let rect = NSMakeRect(screenSize.width/2 - windowSize.width/2, screenSize.height/2 - windowSize.height/2, windowSize.width, windowSize.height)
+        let w = PlanetKeyManagerWindow(contentRect: rect, styleMask: [], backing: .buffered, defer: true)
+        super.init(window: w)
+        self.window?.setFrameAutosaveName("Planet Key Manager Window")
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Planet/Key Manager/PlanetKeyManagerWindowController.swift
+++ b/Planet/Key Manager/PlanetKeyManagerWindowController.swift
@@ -189,10 +189,10 @@ extension PlanetKeyManagerWindowController: NSToolbarDelegate {
             item.target = self
             item.action = #selector(self.toolbarItemAction(_:))
             item.label = "Sync"
-            item.paletteLabel = "Sync to Keychain"
-            item.toolTip = "Sync to Keychain"
+            item.paletteLabel = "Sync with Keychain"
+            item.toolTip = "Sync with Keychain"
             item.isBordered = true
-            item.image = NSImage(systemSymbolName: "key.icloud", accessibilityDescription: "Sync to Keychain")
+            item.image = NSImage(systemSymbolName: "key.icloud", accessibilityDescription: "Sync with Keychain")
             return item
         case .keyManagerImportItem:
             let item = NSToolbarItem(itemIdentifier: itemIdentifier)

--- a/Planet/Key Manager/PlanetKeyManagerWindowController.swift
+++ b/Planet/Key Manager/PlanetKeyManagerWindowController.swift
@@ -161,7 +161,11 @@ extension PlanetKeyManagerWindowController: NSToolbarItemValidation {
             if let selectedKeyItemID = PlanetKeyManagerViewModel.shared.selectedKeyItemID, let keyItem = PlanetKeyManagerViewModel.shared.keys.first(where: { $0.id == selectedKeyItemID }) {
                 let keychainExists: Bool = KeychainHelper.shared.check(forKey: .keyPrefix + keyItem.keyName)
                 let keystoreExists: Bool = PlanetKeyManagerViewModel.shared.keysInKeystore.contains(keyItem.keyName)
-                return !keychainExists || !keystoreExists
+                if !keychainExists && !keystoreExists {
+                    return false
+                } else {
+                    return true
+                }
             }
             return false
         case .keyManagerImportItem:

--- a/Planet/Key Manager/PlanetKeyManagerWindowController.swift
+++ b/Planet/Key Manager/PlanetKeyManagerWindowController.swift
@@ -83,7 +83,7 @@ class PlanetKeyManagerWindowController: NSWindowController {
             throw PlanetError.KeyManagerGeneratingKeyError
         } else if keystoreExists && !keychainExists {
             let (_, keyData) = try generateKeyData()
-            try KeychainHelper.shared.saveData(keyData, forKey: .keyPrefix + keyItem.keyName)
+            try KeychainHelper.shared.saveData(keyData, forKey: .keyPrefix + keyItem.keyName, withICloudSync: true)
         } else if keychainExists && !keystoreExists {
             let theKeyData = try KeychainHelper.shared.loadData(forKey: .keyPrefix + keyItem.keyName, withICloudSync: true)
             let tmpKeyPath = URLUtils.temporaryPath.appendingPathComponent(keyItem.keyName).appendingPathExtension("pem")
@@ -111,7 +111,7 @@ class PlanetKeyManagerWindowController: NSWindowController {
             guard response == .OK, let url = panel.url else { return }
             let keyData = try Data(contentsOf: url)
             try IPFSCommand.importKey(name: keyItem.keyName, target: url, format: "pem-pkcs8-cleartext").run()
-            try KeychainHelper.shared.saveData(keyData, forKey: .keyPrefix + keyItem.keyName)
+            try KeychainHelper.shared.saveData(keyData, forKey: .keyPrefix + keyItem.keyName, withICloudSync: true)
             self.reloadPlanetKeys()
         }
     }

--- a/Planet/Labs/Published Folders/PlanetPublishedServiceStore.swift
+++ b/Planet/Labs/Published Folders/PlanetPublishedServiceStore.swift
@@ -628,7 +628,8 @@ private class PlanetPublishedServiceMonitor {
         monitoredDirectoryFileDescriptor = open((url as NSURL).fileSystemRepresentation, O_EVTONLY)
         directoryMonitorSource = DispatchSource.makeFileSystemObjectSource(fileDescriptor: monitoredDirectoryFileDescriptor, eventMask: [.attrib, .write, .delete], queue: self.monitorQueue) as? DispatchSource
         directoryMonitorSource?.setEventHandler{
-            // MARK: TODO: reloading gracefully.
+            // MARK: TODO: reloading gracefully or manually for now.
+            /*
             Task(priority: .userInitiated) {
                 await MainActor.run {
                     do {
@@ -643,6 +644,7 @@ private class PlanetPublishedServiceMonitor {
                     }
                 }
             }
+             */
         }
         directoryMonitorSource?.setCancelHandler{
             close(self.monitoredDirectoryFileDescriptor)

--- a/Planet/Labs/Published Folders/PlanetPublishedServiceStore.swift
+++ b/Planet/Labs/Published Folders/PlanetPublishedServiceStore.swift
@@ -626,16 +626,16 @@ private class PlanetPublishedServiceMonitor {
     func startMonitoringRepoPath() throws {
         reset()
         monitoredDirectoryFileDescriptor = open((url as NSURL).fileSystemRepresentation, O_EVTONLY)
-        directoryMonitorSource = DispatchSource.makeFileSystemObjectSource(fileDescriptor: monitoredDirectoryFileDescriptor, eventMask: [.all], queue: self.monitorQueue) as? DispatchSource
+        directoryMonitorSource = DispatchSource.makeFileSystemObjectSource(fileDescriptor: monitoredDirectoryFileDescriptor, eventMask: [.attrib, .write, .delete], queue: self.monitorQueue) as? DispatchSource
         directoryMonitorSource?.setEventHandler{
+            // MARK: TODO: reloading gracefully.
             Task(priority: .userInitiated) {
                 await MainActor.run {
                     do {
-                        // MARK: TODO: reload gracefully.
                         try PlanetStore.shared.load()
                         try TemplateStore.shared.load()
-                        PlanetStore.shared.selectedArticle = nil
                         PlanetStore.shared.selectedView = nil
+                        PlanetStore.shared.selectedArticle = nil
                         PlanetStore.shared.selectedArticleList = nil
                         PlanetStore.shared.refreshSelectedArticles()
                     } catch {

--- a/Planet/Labs/Published Folders/PlanetPublishedServiceStore.swift
+++ b/Planet/Labs/Published Folders/PlanetPublishedServiceStore.swift
@@ -54,6 +54,7 @@ class PlanetPublishedServiceStore: ObservableObject {
     @Published private(set) var publishingFolders: [UUID] = []
 
     private var monitors: [PlanetPublishedServiceMonitor] = []
+    private var repoMonitor: PlanetPublishedServiceMonitor?
 
     init() {
         do {
@@ -77,6 +78,25 @@ class PlanetPublishedServiceStore: ObservableObject {
         } catch {
             debugPrint("failed to load published folders: \(error)")
         }
+    }
+    
+    func startRepoPathMonitoring(targetURL: URL) {
+        if repoMonitor != nil {
+            repoMonitor?.reset()
+            repoMonitor = nil
+        }
+        repoMonitor = PlanetPublishedServiceMonitor(url: targetURL, folderID: UUID())
+        do {
+            try repoMonitor?.startMonitoringRepoPath()
+        } catch {
+            debugPrint("failed to start monitoring library path: \(targetURL), error: \(error)")
+            repoMonitor = nil
+        }
+    }
+    
+    func stopRepoPathMonitoring() {
+        repoMonitor?.reset()
+        repoMonitor = nil
     }
     
     func restoreSelectedFolderNavigation() {
@@ -593,6 +613,36 @@ private class PlanetPublishedServiceMonitor {
         directoryMonitorSource = DispatchSource.makeFileSystemObjectSource(fileDescriptor: monitoredDirectoryFileDescriptor, eventMask: DispatchSource.FileSystemEvent.write, queue: self.monitorQueue) as? DispatchSource
         directoryMonitorSource?.setEventHandler{
             PlanetPublishedServiceStore.shared.requestToPublishFolder(withURL: self.url)
+        }
+        directoryMonitorSource?.setCancelHandler{
+            close(self.monitoredDirectoryFileDescriptor)
+            self.monitoredDirectoryFileDescriptor = -1
+            self.directoryMonitorSource = nil
+            self.url.stopAccessingSecurityScopedResource()
+        }
+        directoryMonitorSource?.resume()
+    }
+    
+    func startMonitoringRepoPath() throws {
+        reset()
+        monitoredDirectoryFileDescriptor = open((url as NSURL).fileSystemRepresentation, O_EVTONLY)
+        directoryMonitorSource = DispatchSource.makeFileSystemObjectSource(fileDescriptor: monitoredDirectoryFileDescriptor, eventMask: [.all], queue: self.monitorQueue) as? DispatchSource
+        directoryMonitorSource?.setEventHandler{
+            Task(priority: .userInitiated) {
+                await MainActor.run {
+                    do {
+                        // MARK: TODO: reload gracefully.
+                        try PlanetStore.shared.load()
+                        try TemplateStore.shared.load()
+                        PlanetStore.shared.selectedArticle = nil
+                        PlanetStore.shared.selectedView = nil
+                        PlanetStore.shared.selectedArticleList = nil
+                        PlanetStore.shared.refreshSelectedArticles()
+                    } catch {
+                        debugPrint("failed to reload: \(error)")
+                    }
+                }
+            }
         }
         directoryMonitorSource?.setCancelHandler{
             close(self.monitoredDirectoryFileDescriptor)

--- a/Planet/PlanetAPI.swift
+++ b/Planet/PlanetAPI.swift
@@ -119,7 +119,9 @@ class PlanetAPI: NSObject {
         myPlanets = planets
         var articles: [MyArticleModel] = []
         for planet in planets {
-            articles.append(contentsOf: planet.articles)
+            if planet.articles != nil && planet.articles.count > 0 {
+                articles.append(contentsOf: planet.articles)
+            }
         }
         myArticles = articles
         try? relaunch()

--- a/Planet/PlanetApp.swift
+++ b/Planet/PlanetApp.swift
@@ -64,6 +64,16 @@ struct PlanetApp: App {
                         Text("Publish My Planets")
                     }
                     .keyboardShortcut("p", modifiers: [.command, .shift])
+                    
+                    Button {
+                        Task { @MainActor in
+                            try PlanetStore.shared.load()
+                            try TemplateStore.shared.load()
+                        }
+                    } label: {
+                        Text("Reload My Planets")
+                    }
+                    .disabled(URLUtils.repoPath() == URLUtils.defaultRepoPath)
 
                     Button {
                         planetStore.updateFollowingPlanets()

--- a/Planet/PlanetApp.swift
+++ b/Planet/PlanetApp.swift
@@ -64,16 +64,6 @@ struct PlanetApp: App {
                         Text("Publish My Planets")
                     }
                     .keyboardShortcut("p", modifiers: [.command, .shift])
-                    
-                    Button {
-                        Task { @MainActor in
-                            try PlanetStore.shared.load()
-                            try TemplateStore.shared.load()
-                        }
-                    } label: {
-                        Text("Reload My Planets")
-                    }
-                    .disabled(URLUtils.repoPath() == URLUtils.defaultRepoPath)
 
                     Button {
                         planetStore.updateFollowingPlanets()

--- a/Planet/PlanetApp.swift
+++ b/Planet/PlanetApp.swift
@@ -64,6 +64,26 @@ struct PlanetApp: App {
                         Text("Publish My Planets")
                     }
                     .keyboardShortcut("p", modifiers: [.command, .shift])
+                    
+                    Button {
+                        Task(priority: .userInitiated) {
+                            await MainActor.run {
+                                do {
+                                    try PlanetStore.shared.load()
+                                    try TemplateStore.shared.load()
+                                    PlanetStore.shared.selectedView = nil
+                                    PlanetStore.shared.selectedArticle = nil
+                                    PlanetStore.shared.selectedArticleList = nil
+                                    PlanetStore.shared.refreshSelectedArticles()
+                                } catch {
+                                    debugPrint("failed to reload: \(error)")
+                                }
+                            }
+                        }
+                    } label: {
+                        Text("Reload My Planets")
+                    }
+                    .disabled(URLUtils.repoPath() == URLUtils.defaultRepoPath)
 
                     Button {
                         planetStore.updateFollowingPlanets()

--- a/Planet/PlanetApp.swift
+++ b/Planet/PlanetApp.swift
@@ -39,6 +39,13 @@ struct PlanetApp: App {
                         Text("Template Browser")
                     }
                     .keyboardShortcut("l", modifiers: [.command, .shift])
+                    
+                    Button {
+                        PlanetAppDelegate.shared.openKeyManagerWindow()
+                    } label: {
+                        Text("Key Manager")
+                    }
+                    .keyboardShortcut("k", modifiers: [.command, .shift])
 
                     Button {
                         PlanetAppDelegate.shared.openDownloadsWindow()
@@ -156,6 +163,7 @@ class PlanetAppDelegate: NSObject, NSApplicationDelegate {
     var templateWindowController: TBWindowController?
     var downloadsWindowController: PlanetDownloadsWindowController?
     var publishedFoldersDashboardWindowController: PFDashboardWindowController?
+    var keyManagerWindowController: PlanetKeyManagerWindowController?
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         return true
@@ -283,7 +291,8 @@ class PlanetAppDelegate: NSObject, NSApplicationDelegate {
     }
 }
 
-// MARK: -
+// MARK: - Published Folders Menu UI
+
 extension PlanetApp {
     @ViewBuilder
     private func publishedFoldersMenu() -> some View {
@@ -424,7 +433,8 @@ extension PlanetApp {
     }
 }
 
-// MARK: -
+// MARK: - User Notifications
+
 extension PlanetAppDelegate: UNUserNotificationCenterDelegate {
     func setupNotification() {
         let center = UNUserNotificationCenter.current()
@@ -487,7 +497,8 @@ extension PlanetAppDelegate: UNUserNotificationCenterDelegate {
     }
 }
 
-// MARK: -
+// MARK: - Window Controllers
+
 extension PlanetAppDelegate {
     func openDownloadsWindow() {
         if downloadsWindowController == nil {
@@ -508,6 +519,13 @@ extension PlanetAppDelegate {
             publishedFoldersDashboardWindowController = PFDashboardWindowController()
         }
         publishedFoldersDashboardWindowController?.showWindow(nil)
+    }
+    
+    func openKeyManagerWindow() {
+        if keyManagerWindowController == nil {
+            keyManagerWindowController = PlanetKeyManagerWindowController()
+        }
+        keyManagerWindowController?.showWindow(nil)
     }
 }
 

--- a/Planet/PlanetError.swift
+++ b/Planet/PlanetError.swift
@@ -26,6 +26,10 @@ enum PlanetError: Error {
     case KeychainSavingKeyError
     case KeychainLoadingKeyError
     case KeychainDeletingKeyError
+    case KeychainGeneratingKeyError
+    case KeychainImportingKeyError
+    case KeychainImportingKeyExistsError
+    case KeychainExportingKeyExistsError
     case InternalError
     case UnknownError(Error)
 }

--- a/Planet/PlanetError.swift
+++ b/Planet/PlanetError.swift
@@ -30,6 +30,7 @@ enum PlanetError: Error {
     case KeychainImportingKeyError
     case KeychainImportingKeyExistsError
     case KeychainExportingKeyExistsError
+    case MissingKeyError
     case InternalError
     case UnknownError(Error)
 }

--- a/Planet/PlanetError.swift
+++ b/Planet/PlanetError.swift
@@ -23,6 +23,9 @@ enum PlanetError: Error {
     case MovePublishingPlanetArticleError
     case WalletConnectV2ProjectIDMissingError
     case PublicAPIError
+    case KeychainSaveKeyError
+    case KeychainLoadKeyError
+    case KeychainDeleteKeyError
     case InternalError
     case UnknownError(Error)
 }

--- a/Planet/PlanetError.swift
+++ b/Planet/PlanetError.swift
@@ -1,3 +1,6 @@
+import Foundation
+
+
 enum PlanetError: Error {
     case PersistenceError
     case NetworkError
@@ -6,6 +9,7 @@ enum PlanetError: Error {
     case PlanetFeedError
     case PlanetExistsError
     case MissingTemplateError
+    case MissingPlanetKeyError
     case AvatarError
     case PodcastCoverArtError
     case ImportPlanetError
@@ -23,14 +27,89 @@ enum PlanetError: Error {
     case MovePublishingPlanetArticleError
     case WalletConnectV2ProjectIDMissingError
     case PublicAPIError
-    case KeychainSavingKeyError
-    case KeychainLoadingKeyError
-    case KeychainDeletingKeyError
-    case KeychainGeneratingKeyError
-    case KeychainImportingKeyError
-    case KeychainImportingKeyExistsError
-    case KeychainExportingKeyExistsError
-    case MissingKeyError
+    case KeyManagerSavingKeyError
+    case KeyManagerLoadingKeyError
+    case KeyManagerDeletingKeyError
+    case KeyManagerGeneratingKeyError
+    case KeyManagerImportingKeyError
+    case KeyManagerImportingKeyExistsError
+    case KeyManagerExportingKeyExistsError
     case InternalError
     case UnknownError(Error)
+}
+
+
+extension PlanetError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .PersistenceError:
+            return NSLocalizedString("Persistence Error", comment: "")
+        case .NetworkError:
+            return NSLocalizedString("Network Error", comment: "")
+        case .IPFSError:
+            return NSLocalizedString("IPFS Error", comment: "")
+        case .EthereumError:
+            return NSLocalizedString("Ethereum Error", comment: "")
+        case .PlanetFeedError:
+            return NSLocalizedString("Planet Feed Error", comment: "")
+        case .PlanetExistsError:
+            return NSLocalizedString("Planet Exists Error", comment: "")
+        case .MissingTemplateError:
+            return NSLocalizedString("Missing Template Error", comment: "")
+        case .MissingPlanetKeyError:
+            return NSLocalizedString("Missing Planet Key Error", comment: "")
+        case .AvatarError:
+            return NSLocalizedString("Avatar Error", comment: "")
+        case .PodcastCoverArtError:
+            return NSLocalizedString("Podcast Cover Art Error", comment: "")
+        case .ImportPlanetError:
+            return NSLocalizedString("Import Planet Error", comment: "")
+        case .ExportPlanetError:
+            return NSLocalizedString("Export Planet Error", comment: "")
+        case .FileExistsError:
+            return NSLocalizedString("File Exists Error", comment: "")
+        case .FollowLocalPlanetError:
+            return NSLocalizedString("Follow Local Planet Error", comment: "")
+        case .FollowPlanetVerifyError:
+            return NSLocalizedString("Follow Planet Verify Error", comment: "")
+        case .InvalidPlanetURLError:
+            return NSLocalizedString("Invalid Planet URL Error", comment: "")
+        case .ENSNoContentHashError:
+            return NSLocalizedString("ENS No Content Hash Error", comment: "")
+        case .DotBitNoDWebRecordError:
+            return NSLocalizedString("DotBit No DWeb Record Error", comment: "")
+        case .DotBitIPNSResolveError:
+            return NSLocalizedString("DotBit IPNS Resolve Error", comment: "")
+        case .RenderMarkdownError:
+            return NSLocalizedString("Render Markdown Error", comment: "")
+        case .PublishedServiceFolderUnchangedError:
+            return NSLocalizedString("Published Service Folder Unchanged Error", comment: "")
+        case .PublishedServiceFolderPermissionError:
+            return NSLocalizedString("Published Service Folder Permission Error", comment: "")
+        case .MovePublishingPlanetArticleError:
+            return NSLocalizedString("Move Publishing Planet Article Error", comment: "")
+        case .WalletConnectV2ProjectIDMissingError:
+            return NSLocalizedString("Wallet Connect V2 Project ID Missing Error", comment: "")
+        case .PublicAPIError:
+            return NSLocalizedString("Public API Error", comment: "")
+        case .KeyManagerSavingKeyError:
+            return NSLocalizedString("Key Manager Saving Key Error", comment: "")
+        case .KeyManagerLoadingKeyError:
+            return NSLocalizedString("Key Manager Loading Key Error", comment: "")
+        case .KeyManagerDeletingKeyError:
+            return NSLocalizedString("Key Manager Deleting Key Error", comment: "")
+        case .KeyManagerGeneratingKeyError:
+            return NSLocalizedString("Key Manager Generating Key Error", comment: "")
+        case .KeyManagerImportingKeyError:
+            return NSLocalizedString("Key Manager Importing Key Error", comment: "")
+        case .KeyManagerImportingKeyExistsError:
+            return NSLocalizedString("Key Manager Importing Key Exists Error", comment: "")
+        case .KeyManagerExportingKeyExistsError:
+            return NSLocalizedString("Key Manager Exporting Key Exists Error", comment: "")
+        case .InternalError:
+            return NSLocalizedString("Internal Error", comment: "")
+        case .UnknownError(let error):
+            return error.localizedDescription
+        }
+    }
 }

--- a/Planet/PlanetError.swift
+++ b/Planet/PlanetError.swift
@@ -23,9 +23,9 @@ enum PlanetError: Error {
     case MovePublishingPlanetArticleError
     case WalletConnectV2ProjectIDMissingError
     case PublicAPIError
-    case KeychainSaveKeyError
-    case KeychainLoadKeyError
-    case KeychainDeleteKeyError
+    case KeychainSavingKeyError
+    case KeychainLoadingKeyError
+    case KeychainDeletingKeyError
     case InternalError
     case UnknownError(Error)
 }

--- a/Planet/Settings/PlanetSettingsAPIView.swift
+++ b/Planet/Settings/PlanetSettingsAPIView.swift
@@ -83,8 +83,8 @@ struct PlanetSettingsAPIView: View {
                         apiUsesPasscode = false
                     }
                     Task {
-                        await self.updatePasscode(newValue)
-                        reloadAPIServer()
+                        self.updatePasscode(newValue)
+                        self.reloadAPIServer()
                     }
                 }
             }
@@ -112,7 +112,7 @@ struct PlanetSettingsAPIView: View {
         }
     }
     
-    private func updatePasscode(_ passcode: String) async {
+    private func updatePasscode(_ passcode: String) {
         guard passcode != "" else { return }
         do {
             try KeychainHelper.shared.saveValue(passcode, forKey: .settingsAPIPasscode)

--- a/Planet/Settings/PlanetSettingsGeneralView.swift
+++ b/Planet/Settings/PlanetSettingsGeneralView.swift
@@ -28,6 +28,12 @@ struct PlanetSettingsGeneralView: View {
                     }
                 }
             }
+            // Update library path monitoring
+            if URLUtils.repoPath().path == libraryLocation {
+                PlanetPublishedServiceStore.shared.stopRepoPathMonitoring()
+            } else {
+                PlanetPublishedServiceStore.shared.startRepoPathMonitoring(targetURL: URLUtils.repoPath())
+            }
         }
     }
 

--- a/Planet/TemplateBrowser/TemplateBrowserView.swift
+++ b/Planet/TemplateBrowser/TemplateBrowserView.swift
@@ -12,76 +12,7 @@ struct TemplateBrowserView: View {
         NavigationView {
             TemplateBrowserSidebar()
             TemplatePreviewView()
-//                .navigationTitle(template?.name ?? "Template Browser")
-//                .navigationSubtitle(navigationSubtitle())
-//                .toolbar {
-//                    ToolbarItemGroup(placement: .primaryAction) {
-//                        Spacer()
-//
-//                        if hasVSCode() {
-//                            Button {
-//                                openVSCode()
-//                            } label: {
-//                                Image(systemName: "chevron.left.forwardslash.chevron.right")
-//                            }.help("Open in VSCode")
-//                        }
-//
-//                        Button {
-//                            revealInFinder()
-//                        } label: {
-//                            Image(systemName: "folder")
-//                        }.help("Reveal in Finder")
-//
-//                        Button {
-//                            refresh()
-//                        } label: {
-//                            Image(systemName: "arrow.clockwise")
-//                        }.help("Refresh")
-//                    }
-//                }
-//                .edgesIgnoringSafeArea(.vertical)
         }
-    }
-
-    private func hasVSCode() -> Bool {
-        NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.microsoft.VSCode") != nil
-    }
-
-    private func openVSCode() {
-//        guard
-//            let appUrl = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.microsoft.VSCode")
-//        else { return }
-//        guard let template = template else { return }
-//
-//        let url = URL(fileURLWithPath: template.path.path)
-//        NSWorkspace.shared.open([url], withApplicationAt: appUrl, configuration: self.openConfiguration(), completionHandler: nil)
-    }
-
-    private func openConfiguration() -> NSWorkspace.OpenConfiguration {
-        let conf = NSWorkspace.OpenConfiguration()
-        conf.hidesOthers = false
-        conf.hides = false
-        conf.activates = true
-        return conf
-    }
-
-    private func revealInFinder() {
-//        guard let template = template else { return }
-//        let url = URL(fileURLWithPath: template.path.path)
-//        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: url.path)
-    }
-
-    private func refresh() {
-        NotificationCenter.default.post(name: .refreshTemplatePreview, object: nil)
-    }
-
-    private func navigationSubtitle() -> String {
-//        if let template = template {
-//            return "\(template.author) · Version \(template.version)"
-//        } else {
-//            return ""
-//        }
-        return ""
     }
 }
 

--- a/Planet/TemplateBrowser/Window Controller/TBWindowController.swift
+++ b/Planet/TemplateBrowser/Window Controller/TBWindowController.swift
@@ -99,7 +99,7 @@ class TBWindowController: NSWindowController {
         self.window?.subtitle = "\(template.author) · Version \(template.version)"
     }
 
-    @objc func toolbarItemAction(_ sender: Any) {
+    @objc private func toolbarItemAction(_ sender: Any) {
         guard let item = sender as? NSToolbarItem else { return }
         switch item.itemIdentifier {
             case .templateSidebarItem:


### PR DESCRIPTION
- Added Key Manager UI to manage planet keys (Tools > Key Manager)
- Added ```KeychainHelper.swift``` to handle password in Keychain, with iCloud sync.
- Added description for PlanetError
- Removed two dependencies: Alamofire, keychain-swift
- Abort publishing when planet key is missing

Now we can reload my planets manually from the menu bar command: Tools > Reload My Planets, it's useful when a shared location is used by multiple planets. Automatically monitoring and reloading is disabled (implemented) for now due to unsafe refreshing and disk monitoring.

Also the Key Manager makes it easy to export & import missing keys for synced planets if shared library location is used.
