### PR TITLE
Add basic GIF animation support in media view.

### DIFF
--- a/Planet.xcodeproj/project.pbxproj
+++ b/Planet.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		2A441BAE27C40BD30008A694 /* WriterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A441BAD27C40BD30008A694 /* WriterView.swift */; };
 		2A441BB027C4DD980008A694 /* CreatePlanetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A441BAF27C4DD980008A694 /* CreatePlanetView.swift */; };
 		2A441BB327C4DF110008A694 /* FollowPlanetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A441BB227C4DF110008A694 /* FollowPlanetView.swift */; };
+		2A466FD12A809E2C009FB646 /* GIFIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A466FD02A809E2C009FB646 /* GIFIndicatorView.swift */; };
+		2A466FD22A809E2C009FB646 /* GIFIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A466FD02A809E2C009FB646 /* GIFIndicatorView.swift */; };
+		2A466FD42A809F65009FB646 /* ASMediaView in Frameworks */ = {isa = PBXBuildFile; productRef = 2A466FD32A809F65009FB646 /* ASMediaView */; };
 		2A6247AE292CC5F400714BFA /* IndicatorLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6247AD292CC5F400714BFA /* IndicatorLabelView.swift */; };
 		2A68C6232A26F07A0079AD5F /* RebuildProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A18F2052A0F0FA700FC4050 /* RebuildProgressView.swift */; };
 		2A69F04727E1B53A00141DC0 /* FeedKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2A69F04627E1B53A00141DC0 /* FeedKit */; };
@@ -433,6 +436,7 @@
 		2A441BAD27C40BD30008A694 /* WriterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterView.swift; sourceTree = "<group>"; };
 		2A441BAF27C4DD980008A694 /* CreatePlanetView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreatePlanetView.swift; sourceTree = "<group>"; };
 		2A441BB227C4DF110008A694 /* FollowPlanetView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowPlanetView.swift; sourceTree = "<group>"; };
+		2A466FD02A809E2C009FB646 /* GIFIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GIFIndicatorView.swift; sourceTree = "<group>"; };
 		2A6247AD292CC5F400714BFA /* IndicatorLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicatorLabelView.swift; sourceTree = "<group>"; };
 		2A6E16D52A18678E00704A08 /* AppSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSidebarView.swift; sourceTree = "<group>"; };
 		2A6E16D72A18679A00704A08 /* AppContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppContentView.swift; sourceTree = "<group>"; };
@@ -650,6 +654,7 @@
 			files = (
 				6AB6E515291527B800F17328 /* WalletConnectPairing in Frameworks */,
 				BB7FC8752898C70A00359802 /* libcmark_gfm in Frameworks */,
+				2A466FD42A809F65009FB646 /* ASMediaView in Frameworks */,
 				BBAE651B28987A31007E1818 /* HTMLEntities in Frameworks */,
 				6A9C211029792464005A815E /* AVKit.framework in Frameworks */,
 				BB99C7072847AC9F001836B2 /* Sparkle in Frameworks */,
@@ -1164,6 +1169,7 @@
 				72114E6F20DEF821BA928CB2 /* AudioPlayer.swift */,
 				2AFFD51A28AD760400EDB020 /* HelpLinkButton.swift */,
 				2A052AC0290971E80028E88F /* ArtworkView.swift */,
+				2A466FD02A809E2C009FB646 /* GIFIndicatorView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1263,6 +1269,7 @@
 				6A71896A2947FD0500279D77 /* Web3ContractABI */,
 				6A71896C2947FD0500279D77 /* Web3PromiseKit */,
 				2AB6A93D29703825007186A7 /* Swifter */,
+				2A466FD32A809F65009FB646 /* ASMediaView */,
 			);
 			productName = Planet;
 			productReference = 2AC4994527BB6E7500F1C2D1 /* Planet.app */;
@@ -1483,6 +1490,7 @@
 				2A95E6DF2A19A521001288B8 /* Plausible.swift in Sources */,
 				2A95E6FD2A1B003D001288B8 /* MyPlanetEditView.swift in Sources */,
 				2A996AD62A1DA6C700BEF898 /* PlanetDownloadsViewModel.swift in Sources */,
+				2A466FD22A809E2C009FB646 /* GIFIndicatorView.swift in Sources */,
 				2A95E6772A19A3C4001288B8 /* URLUtils.swift in Sources */,
 				2A6E16DA2A186B0100704A08 /* AppWindow.swift in Sources */,
 				2ABD1CC42A1616DA0082D7EA /* AppDelegate.swift in Sources */,
@@ -1636,6 +1644,7 @@
 				6A2F5F1528DB767A00034D55 /* dWebServices.swift in Sources */,
 				72114A65C35BF78B1A4B7D81 /* DraftModel.swift in Sources */,
 				2AE44EA928CD214800944786 /* PlanetSettingsView.swift in Sources */,
+				2A466FD12A809E2C009FB646 /* GIFIndicatorView.swift in Sources */,
 				2A79FB2C2898184100F06DDF /* PlanetDownloadModel.swift in Sources */,
 				2A4164D729E64878009BFC24 /* PlanetQuickShareViewModel.swift in Sources */,
 				6AC01AF0291ECC7E00EB6B5F /* WalletAccountView.swift in Sources */,
@@ -2077,6 +2086,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2A466FD32A809F65009FB646 /* ASMediaView */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2AFDF8A82A3A1E8500386B9A /* XCRemoteSwiftPackageReference "mediaview" */;
+			productName = ASMediaView;
+		};
 		2A69F04627E1B53A00141DC0 /* FeedKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2A69F04527E1B53A00141DC0 /* XCRemoteSwiftPackageReference "FeedKit" */;

--- a/Planet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Planet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/airwolfspace/mediaview",
       "state" : {
         "branch" : "main",
-        "revision" : "f4c8235dc23dda742dc6579568ef96a02b3661a5"
+        "revision" : "5f3590128f613ab4b591f2ec475fbf2d596f0868"
       }
     },
     {

--- a/Planet/Quick Share/PlanetQuickShareView.swift
+++ b/Planet/Quick Share/PlanetQuickShareView.swift
@@ -6,6 +6,8 @@
 //
 
 import SwiftUI
+import ASMediaView
+
 
 struct PlanetQuickShareView: View {
     @StateObject private var viewModel: PlanetQuickShareViewModel
@@ -73,20 +75,30 @@ struct PlanetQuickShareView: View {
             }
         } else if viewModel.fileURLs.count == 1, let url = viewModel.fileURLs.first, let img = NSImage(contentsOf: url) {
             HStack {
-                Image(nsImage: img)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 180, height: 180)
+                ZStack {
+                    Image(nsImage: img)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                    if PlanetStore.shared.app == .lite && ASMediaManager.shared.imageIsGIF(image: img) {
+                        GIFIndicatorView()
+                    }
+                }
+                .frame(width: 180, height: 180)
             }
         } else {
             ScrollView(.horizontal) {
                 LazyHStack(alignment: .center) {
                     ForEach(viewModel.fileURLs, id: \.self) { url in
                         if let img = NSImage(contentsOf: url) {
-                            Image(nsImage: img)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 180, height: 180)
+                            ZStack {
+                                Image(nsImage: img)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                if PlanetStore.shared.app == .lite && ASMediaManager.shared.imageIsGIF(image: img) {
+                                    GIFIndicatorView()
+                                }
+                            }
+                            .frame(width: 180, height: 180)
                         }
                     }
                 }

--- a/Planet/Views/Components/GIFIndicatorView.swift
+++ b/Planet/Views/Components/GIFIndicatorView.swift
@@ -1,0 +1,31 @@
+//
+//  GIFIndicatorView.swift
+//  Planet
+//
+//  Created by Kai on 8/7/23.
+//
+
+import SwiftUI
+
+
+struct GIFIndicatorView: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Text("GIF")
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.85))
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.75))
+                    .cornerRadius(4)
+                    .multilineTextAlignment(.center)
+                Spacer()
+            }
+            .padding(.leading, 4)
+            .padding(.bottom, 4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}


### PR DESCRIPTION
- Added basic GIF animation support in media view
- Fixed empty media view window title, now will use article uuid instead. https://github.com/Planetable/Planet/issues/251
- Improved memory usage in media view