### PR TITLE
Update media view framework, using minor version dependency.

### DIFF
--- a/Planet.xcodeproj/project.pbxproj
+++ b/Planet.xcodeproj/project.pbxproj
@@ -2370,8 +2370,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airwolfspace/mediaview";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		6A2A4D2A2A86422700F4491A /* XCRemoteSwiftPackageReference "WrappingHStack" */ = {

--- a/Planet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Planet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airwolfspace/mediaview",
       "state" : {
-        "branch" : "main",
-        "revision" : "b1442b2371bd7c141f86b1331c83358bf1885806"
+        "revision" : "c64f8e9056203cdde5493ed469b350e14217b053",
+        "version" : "1.0.0"
       }
     },
     {

--- a/PlanetLite/AppContentItemView.swift
+++ b/PlanetLite/AppContentItemView.swift
@@ -88,9 +88,19 @@ struct AppContentItemView: View {
     
     private func processAttachments(_ urls: [URL]) {
         if article.hasVideo {
-            ASMediaManager.shared.activateVideoView(withVideos: urls, title: article.title, andID: article.id)
+            DispatchQueue.global(qos: .userInitiated).async {
+                if let videoThumbnail = self.article.getVideoThumbnail(), !CGSizeEqualToSize(.zero, videoThumbnail.size) {
+                    DispatchQueue.main.async {
+                        ASMediaManager.shared.activateVideoView(withVideos: urls, title: self.article.title, id: self.article.id, defaultSize: videoThumbnail.size)
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        ASMediaManager.shared.activateVideoView(withVideos: urls, title: self.article.title, id: self.article.id)
+                    }
+                }
+            }
         } else {
-            ASMediaManager.shared.activatePhotoView(withPhotos: urls, title: article.title, andID: article.id)
+            ASMediaManager.shared.activatePhotoView(withPhotos: urls, title: article.title, id: article.id)
         }
     }
 


### PR DESCRIPTION
- Fixed the random initial window position issue
- Removed the on loading resizing animation logic/issue for all kinds of media by using a new default size parameter

WIP:
- There's a known issue when viewing group GIF images
- The default video player size may have inaccurate aspect ratio

I've changed the media view framework dependency to minor versions in this PR, it's more convenient now to keep updating for coming updates (minor versions).