### PR TITLE
Add Menubar icon

### DIFF
--- a/Planet.xcodeproj/project.pbxproj
+++ b/Planet.xcodeproj/project.pbxproj
@@ -536,6 +536,8 @@
 		BB99C7072847AC9F001836B2 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = BB99C7062847AC9F001836B2 /* Sparkle */; };
 		BBAE651B28987A31007E1818 /* HTMLEntities in Frameworks */ = {isa = PBXBuildFile; productRef = BBAE651A28987A31007E1818 /* HTMLEntities */; };
 		BBC831AB2836239300CE1F67 /* PlanetSiteTemplates in Frameworks */ = {isa = PBXBuildFile; productRef = BBC831AA2836239300CE1F67 /* PlanetSiteTemplates */; };
+		BBCD7E5B2DDC455600F65E91 /* MenuBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBCD7E592DDC455600F65E91 /* MenuBarManager.swift */; };
+		BBCD7E5C2DDC455600F65E91 /* MenuBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBCD7E592DDC455600F65E91 /* MenuBarManager.swift */; };
 		BBFE51EC27F3AABC0055A51A /* ENSKit in Frameworks */ = {isa = PBXBuildFile; productRef = BBFE51EB27F3AABC0055A51A /* ENSKit */; };
 		E8B4FE3D2A8D144E00C01E94 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E8B4FE3F2A8D144E00C01E94 /* Localizable.strings */; };
 		E8B4FE422A8D146100C01E94 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E8B4FE442A8D146100C01E94 /* InfoPlist.strings */; };
@@ -867,6 +869,7 @@
 		BB8ADF83282580130024DEE2 /* Planet v6.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Planet v6.xcdatamodel"; sourceTree = "<group>"; };
 		BBC60A1A2803931C007A42D0 /* Planet v5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Planet v5.xcdatamodel"; sourceTree = "<group>"; };
 		BBC831AC2837075600CE1F67 /* Planet v7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Planet v7.xcdatamodel"; sourceTree = "<group>"; };
+		BBCD7E592DDC455600F65E91 /* MenuBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarManager.swift; sourceTree = "<group>"; };
 		E8B4FE3E2A8D144E00C01E94 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		E8B4FE432A8D146100C01E94 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1366,6 +1369,7 @@
 		6A1DA07A28B4273C00C6B5A9 /* Labs */ = {
 			isa = PBXGroup;
 			children = (
+				BBCD7E5A2DDC455600F65E91 /* Menubar */,
 				6A2827D22BD88E6C006B4A84 /* Quick Post */,
 				2A27744C2A9515C300A5DDC2 /* Icon Gallery */,
 				6AB6E4F92915226400F17328 /* Wallet */,
@@ -1637,6 +1641,14 @@
 				6A43E7D02B873F4900316F81 /* SearchResult.swift */,
 			);
 			path = Entities;
+			sourceTree = "<group>";
+		};
+		BBCD7E5A2DDC455600F65E91 /* Menubar */ = {
+			isa = PBXGroup;
+			children = (
+				BBCD7E592DDC455600F65E91 /* MenuBarManager.swift */,
+			);
+			path = Menubar;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1992,6 +2004,7 @@
 				2A95E6692A19A3AF001288B8 /* TB+Extension.swift in Sources */,
 				2A95E66A2A19A3AF001288B8 /* TBWindowController.swift in Sources */,
 				2A95E64F2A19A398001288B8 /* PFDashboardInspectorView.swift in Sources */,
+				BBCD7E5B2DDC455600F65E91 /* MenuBarManager.swift in Sources */,
 				2A95E6482A19A398001288B8 /* PFDashboardViewController.swift in Sources */,
 				2A95E67D2A19A3C4001288B8 /* WKScriptHelper.swift in Sources */,
 				6AFCF7E72B737371002299BA /* TemplateMonitor.swift in Sources */,
@@ -2178,6 +2191,7 @@
 				2A2F70EC2967057100755931 /* WriterTitleView.swift in Sources */,
 				2AA7974829496F730031E873 /* PlanetPublishedFolders+Extension.swift in Sources */,
 				6AABC6AC291A698B009FD13F /* WalletConnectV1QRCodeView.swift in Sources */,
+				BBCD7E5C2DDC455600F65E91 /* MenuBarManager.swift in Sources */,
 				6A8776D42A01B78800C6003B /* Pinnable.swift in Sources */,
 				6A52FAEF2A88969A000E85F0 /* BackupMyPlanetModel.swift in Sources */,
 				2A0E91902BE8EFC600F69578 /* IPFSStatusView.swift in Sources */,

--- a/Planet/Entities/PlanetStore.swift
+++ b/Planet/Entities/PlanetStore.swift
@@ -132,10 +132,10 @@ enum PlanetDetailViewType: Hashable, Equatable {
     @Published var isMigrating = false
     @Published var isRebuilding = false
     @Published var rebuildTasks: Int = 0
-    @Published var isQuickSharing = false  // use in macOS 12 only.
+    @Published var isQuickSharing = false // use in macOS 12 only.
     @Published var isQuickPosting = false
 
-    @Published var isAggregating: Bool = false  // at any time, only one aggregation task is allowed.
+    @Published var isAggregating: Bool = false // at any time, only one aggregation task is allowed.
     @Published var currentTaskMessage: String = ""
     @Published var currentTaskProgressIndicator: TaskProgressIndicatorType = .none
 
@@ -470,7 +470,7 @@ enum PlanetDetailViewType: Hashable, Equatable {
     func getUnreadArticles() -> [ArticleModel] {
         var articles = followingPlanets.flatMap { followingPlanet in
             followingPlanet.articles.filter {
-                if ($0.read == nil) {
+                if $0.read == nil {
                     return true
                 } else {
                     return false
@@ -501,9 +501,9 @@ enum PlanetDetailViewType: Hashable, Equatable {
             throw PlanetError.MovePublishingPlanetArticleError
         }
         debugPrint("moving article: \(article), from planet: \(fromPlanet), to planet: \(toPlanet)")
-        fromPlanet.articles = fromPlanet.articles.filter({ a in
-            return a.id != article.id
-        })
+        fromPlanet.articles = fromPlanet.articles.filter { a in
+            a.id != article.id
+        }
         let articleIDString: String = article.id.uuidString.uppercased()
         let fromPlanetIDString: String = fromPlanet.id.uuidString.uppercased()
         let toPlanetIDString: String = toPlanet.id.uuidString.uppercased()
@@ -566,7 +566,7 @@ enum PlanetDetailViewType: Hashable, Equatable {
         let refreshedArticle = try MyArticleModel.load(from: movedArticle.path, planet: refreshedToPlanet)
         try refreshedArticle.savePublic()
 
-        myPlanets = myPlanets.map() { p in
+        myPlanets = myPlanets.map { p in
             if p.id == refreshedFromPlanet.id {
                 return refreshedFromPlanet
             } else if p.id == refreshedToPlanet.id {

--- a/Planet/Helper/Extensions.swift
+++ b/Planet/Helper/Extensions.swift
@@ -150,6 +150,10 @@ extension String {
     static let liteAppName = "Croptop"
 }
 
+extension URL {
+    static let mainEvent = URL(string: "planet://Planet")!
+}
+
 extension Notification.Name {
     static let killHelper = Notification.Name("PlanetKillPlanetHelperNotification")
     static let terminateDaemon = Notification.Name("PlanetTerminatePlanetDaemonNotification")

--- a/Planet/Helper/Extensions.swift
+++ b/Planet/Helper/Extensions.swift
@@ -21,6 +21,8 @@ extension String {
     static let settingsPublicGatewayIndex: String = "PlanetSettingsPublicGatewayIndexKey"
     static let settingsPreferredIPFSPublicGateway: String = "PlanetSettingsPreferredIPFSPublicGatewayKey"
     static let settingsWarnBeforeQuitIfPublishing: String = "PlanetSettingsWarnBeforeQuitIfPublishingKey"
+    static let settingsShowMenuBarIcon: String = "PlanetSettingsShowMenuBarIconKey"
+    static let settingsHideDockIcon: String = "PlanetSettingsHideDockIconKey"
     static let settingsEthereumChainId: String = "PlanetSettingsEthereumChainId"
     static let settingsEthereumTipAmount: String = "PlanetSettingsEthereumTipAmount"
     static let settingsAPIEnabled: String = "PlanetSettingsAPIEnabledKey"
@@ -230,10 +232,10 @@ extension Date {
 }
 
 protocol URLQueryParameterStringConvertible {
-    var queryParameters: String {get}
+    var queryParameters: String { get }
 }
 
-extension Dictionary : URLQueryParameterStringConvertible {
+extension Dictionary: URLQueryParameterStringConvertible {
     var queryParameters: String {
         var parts: [String] = []
         for (key, value) in self {
@@ -247,8 +249,8 @@ extension Dictionary : URLQueryParameterStringConvertible {
 }
 
 extension URL {
-    func appendingQueryParameters(_ parametersDictionary : Dictionary<String, String>) -> URL {
-        let URLString : String = String(format: "%@?%@", absoluteString, parametersDictionary.queryParameters)
+    func appendingQueryParameters(_ parametersDictionary: [String: String]) -> URL {
+        let URLString = String(format: "%@?%@", absoluteString, parametersDictionary.queryParameters)
         return URL(string: URLString)!
     }
 

--- a/Planet/Labs/Menubar/MenuBarManager.swift
+++ b/Planet/Labs/Menubar/MenuBarManager.swift
@@ -78,7 +78,7 @@ class MenuBarManager: NSObject {
             return
         }
 
-        if let icon = NSImage(systemSymbolName: "cricket.ball.fill", accessibilityDescription: nil) {
+        if let icon = NSImage(systemSymbolName: "globe.asia.australia", accessibilityDescription: nil) {
             icon.size = NSSize(width: 20, height: 20)
             icon.isTemplate = true
             button.image = icon

--- a/Planet/Labs/Menubar/MenuBarManager.swift
+++ b/Planet/Labs/Menubar/MenuBarManager.swift
@@ -134,13 +134,14 @@ class MenuBarManager: NSObject {
 
     @objc func showMainWindow() {
         let app = NSApplication.shared
-        app.activate(ignoringOtherApps: true)
-        if let mainWindow = app.windows.first(where: { $0.canBecomeMain && $0.isMainWindow }) {
-            mainWindow.makeKeyAndOrderFront(nil)
-        } else if let firstWindow = app.windows.first(where: { $0.canBecomeMain && !$0.isVisible } ) {
-            firstWindow.makeKeyAndOrderFront(nil)
-        } else {
-
+        let current = app.activationPolicy()
+        guard let window = app.windows.first(where: { $0.className == "SwiftUI.AppKitWindow" }) else {
+            return
         }
+        if !window.canBecomeMain || !window.isVisible {
+            NSWorkspace.shared.open(.mainEvent)
+            NSApplication.shared.setActivationPolicy(current)
+        }
+        window.makeKeyAndOrderFront(nil)
     }
 }

--- a/Planet/Labs/Menubar/MenuBarManager.swift
+++ b/Planet/Labs/Menubar/MenuBarManager.swift
@@ -1,0 +1,146 @@
+import AppKit
+import SwiftUI
+
+class MenuBarManager: NSObject {
+    static let shared = MenuBarManager()
+
+    private var statusItem: NSStatusItem?
+
+    init(defaults: UserDefaults = .standard) {
+        if defaults.value(forKey: .settingsShowMenuBarIcon) == nil {
+            defaults.set(true, forKey: .settingsShowMenuBarIcon)
+        }
+        if defaults.value(forKey: .settingsHideDockIcon) == nil {
+            defaults.set(false, forKey: .settingsHideDockIcon)
+        }
+    }
+
+    func setupMenuBar() {
+        updateMenuBarVisibility(UserDefaults.standard.bool(forKey: .settingsShowMenuBarIcon))
+        updateDockIconVisibility(UserDefaults.standard.bool(forKey: .settingsHideDockIcon))
+    }
+
+    func updateMenuBarVisibility(_ shouldShow: Bool) {
+        DispatchQueue.main.async {
+            if shouldShow {
+                if self.statusItem == nil {
+                    self.createMenuBarIcon()
+                } else {
+                    self.statusItem?.isVisible = true
+                }
+            } else {
+                if self.statusItem != nil {
+                    self.removeMenuBarIcon()
+                }
+                // Activate app window only when switching to regular mode
+                if let window = NSApp.windows.first(where: { $0.canBecomeMain }) {
+                    NSApplication.shared.activate(ignoringOtherApps: true)
+                    window.makeKeyAndOrderFront(nil)
+                }
+            }
+        }
+    }
+
+    func updateDockIconVisibility(_ shouldHide: Bool) {
+        if shouldHide {
+            NSApplication.shared.setActivationPolicy(.accessory)
+        } else {
+            NSApplication.shared.setActivationPolicy(.regular)
+        }
+    }
+
+    private func createMenuBarIcon() {
+        guard statusItem == nil else {
+            return
+        }
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+
+        guard let button = statusItem?.button else {
+            if let item = statusItem { NSStatusBar.system.removeStatusItem(item) }
+            statusItem = nil
+            return
+        }
+
+        if let icon = NSImage(systemSymbolName: "cricket.ball.fill", accessibilityDescription: nil) {
+            icon.size = NSSize(width: 18, height: 18)
+            icon.isTemplate = true
+            button.image = icon
+        } else {
+            button.title = "🪐"
+        }
+
+        button.action = #selector(statusBarButtonClicked(sender:))
+        button.target = self
+
+        // Build the menu
+        let menu = NSMenu()
+
+        let aboutMenuItem = NSMenuItem(
+            title: "About",
+            action: #selector(showAbout),
+            keyEquivalent: ""
+        )
+        aboutMenuItem.target = self
+        menu.addItem(aboutMenuItem)
+
+        // Add Settings Menu Item
+        let settingsMenuItem = NSMenuItem(
+            title: "Show Main Window",
+            action: #selector(showMainWindow),
+            keyEquivalent: ""
+        )
+        settingsMenuItem.target = self
+        menu.addItem(settingsMenuItem)
+
+        // Separator before Toggle Item
+        menu.addItem(NSMenuItem.separator())
+
+        menu.addItem(NSMenuItem(
+            title: "Quit",
+            action: #selector(NSApplication.terminate(_:)),
+            keyEquivalent: "q"
+        )
+        )
+
+        statusItem?.menu = menu
+        statusItem?.isVisible = true
+    }
+
+    private func removeMenuBarIcon() {
+        guard let item = statusItem else {
+            return
+        }
+        NSStatusBar.system.removeStatusItem(item)
+        statusItem = nil
+    }
+
+    // --- Actions ---
+
+    @objc func toggleMenuBarPreference() {
+        let currentSetting = UserDefaults.standard.bool(
+            forKey: .settingsShowMenuBarIcon
+        )
+        let newSetting = !currentSetting
+        UserDefaults.standard.set(newSetting, forKey: .settingsShowMenuBarIcon)
+        updateMenuBarVisibility(newSetting)
+    }
+
+    @objc func statusBarButtonClicked(sender: NSStatusBarButton) {}
+
+    @objc func showAbout() {
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.orderFrontStandardAboutPanel(nil)
+    }
+
+    @objc func showMainWindow() {
+        let app = NSApplication.shared
+        app.activate(ignoringOtherApps: true)
+        if let mainWindow = app.windows.first(where: { $0.canBecomeMain && $0.isMainWindow }) {
+            mainWindow.makeKeyAndOrderFront(nil)
+        } else if let firstWindow = app.windows.first(where: { $0.canBecomeMain && !$0.isVisible } ) {
+            firstWindow.makeKeyAndOrderFront(nil)
+        } else {
+
+        }
+    }
+}

--- a/Planet/PlanetApp.swift
+++ b/Planet/PlanetApp.swift
@@ -20,6 +20,7 @@ struct PlanetApp: App {
         _iconManager = StateObject(wrappedValue: IconManager.shared)
         _keyboardHelper = ObservedObject(wrappedValue: KeyboardShortcutHelper.shared)
         _apiController = ObservedObject(wrappedValue: PlanetAPIController.shared)
+        MenuBarManager.shared.setupMenuBar()
     }
 
     var body: some Scene {

--- a/Planet/PlanetApp.swift
+++ b/Planet/PlanetApp.swift
@@ -90,7 +90,7 @@ struct PlanetApp: App {
 
     @SceneBuilder
     private func planetMainWindowGroup() -> some Scene {
-        let mainEvent: Set<String> = Set(arrayLiteral: "planet://Planet")
+        let mainEvent: Set<String> = Set(arrayLiteral: URL.mainEvent.absoluteString)
         WindowGroup("Planet") {
             PlanetMainView()
                 .environmentObject(planetStore)

--- a/Planet/Settings/PlanetSettingsGeneralView.swift
+++ b/Planet/Settings/PlanetSettingsGeneralView.swift
@@ -135,6 +135,11 @@ struct PlanetSettingsGeneralView: View {
                                 .onChange(of: showMenuBarIcon) { newValue in
                                     Task { @MainActor in
                                         MenuBarManager.shared.updateMenuBarVisibility(newValue)
+                                        UserDefaults.standard
+                                            .set(
+                                                newValue,
+                                                forKey: .settingsShowMenuBarIcon
+                                            )
                                     }
                                 }
                             Toggle("Hide Dock Icon", isOn: $hideDockIcon)
@@ -142,6 +147,11 @@ struct PlanetSettingsGeneralView: View {
                                     Task { @MainActor in
                                         MenuBarManager.shared
                                             .updateDockIconVisibility(newValue)
+                                        UserDefaults.standard
+                                            .set(
+                                                newValue,
+                                                forKey: .settingsHideDockIcon
+                                            )
                                     }
                                 }
                         }

--- a/Planet/Settings/PlanetSettingsGeneralView.swift
+++ b/Planet/Settings/PlanetSettingsGeneralView.swift
@@ -32,13 +32,15 @@ struct PlanetSettingsGeneralView: View {
 
     @AppStorage(String.settingsPreferredIPFSPublicGateway) private var preferredIPFSPublicGateway:
         String =
-            UserDefaults.standard.string(forKey: String.settingsPreferredIPFSPublicGateway)
+        UserDefaults.standard.string(forKey: String.settingsPreferredIPFSPublicGateway)
             ?? IPFSGateway.defaultGateway.rawValue
 
     @AppStorage(String.settingsEthereumChainId) private var ethereumChainId: Int = UserDefaults
         .standard.integer(forKey: String.settingsEthereumChainId)
 
     @AppStorage(String.settingsWarnBeforeQuitIfPublishing) private var warnBeforeQuitIfPublishing = false
+    @AppStorage(String.settingsShowMenuBarIcon) private var showMenuBarIcon: Bool = true
+    @AppStorage(String.settingsHideDockIcon) private var hideDockIcon: Bool = false
 
     var body: some View {
         Form {
@@ -96,7 +98,7 @@ struct PlanetSettingsGeneralView: View {
                             }
                         }
                         .pickerStyle(.menu)
-                        .onChange(of: preferredIPFSPublicGateway) { newValue in
+                        .onChange(of: preferredIPFSPublicGateway) { _ in
                             // Refresh Published Folders Dashboard Toolbar
                             NotificationCenter.default.post(
                                 name: .dashboardRefreshToolbar,
@@ -120,6 +122,30 @@ struct PlanetSettingsGeneralView: View {
                         .font(.footnote)
                         .foregroundColor(.secondary)
                         .padding(.leading, PlanetUI.SETTINGS_CAPTION_WIDTH - 10)
+                    }
+
+                    HStack(spacing: 10) {
+                        Text("App Behavior")
+                            .frame(
+                                width: PlanetUI.SETTINGS_CAPTION_WIDTH,
+                                alignment: .trailing
+                            )
+                        VStack(alignment: .leading, spacing: 10) {
+                            Toggle("Show Menu Bar Icon", isOn: $showMenuBarIcon)
+                                .onChange(of: showMenuBarIcon) { newValue in
+                                    Task { @MainActor in
+                                        MenuBarManager.shared.updateMenuBarVisibility(newValue)
+                                    }
+                                }
+                            Toggle("Hide Dock Icon", isOn: $hideDockIcon)
+                                .onChange(of: hideDockIcon) { newValue in
+                                    Task { @MainActor in
+                                        MenuBarManager.shared
+                                            .updateDockIconVisibility(newValue)
+                                    }
+                                }
+                        }
+                        Spacer()
                     }
 
                     #if DEBUG
@@ -181,7 +207,7 @@ struct PlanetSettingsGeneralView: View {
         let response = panel.runModal()
         guard response == .OK, let url = panel.url else { return }
         let planetURL = url.appendingPathComponent("Planet")
-        var useAsExistingLibraryLocation: Bool = false
+        var useAsExistingLibraryLocation = false
         if FileManager.default.fileExists(atPath: planetURL.path) {
             useAsExistingLibraryLocation = true
         }

--- a/Planet/Settings/PlanetSettingsView.swift
+++ b/Planet/Settings/PlanetSettingsView.swift
@@ -23,7 +23,7 @@ struct PlanetSettingsView: View {
                     Label("General", systemImage: "gearshape")
                 }
                 .tag(PlanetSettingsTab.general)
-                .frame(width: 420, height: 320)
+                .frame(width: 420, height: 340)
                 .environmentObject(store)
 
             PlanetSettingsPlanetsView()


### PR DESCRIPTION
Fixes https://github.com/Planetable/Planet/issues/426, status item image is `globe.asia.australia` (needs to be a template / vector format), feel free to replace it with proper Planet style icon.

Changes:
- Add `PlanetSettingsShowMenuBarIconKey` and `PlanetSettingsHideDockIconKey` to `General` preference.
- Add `MenuBarManager` and menu items
- - IPFS gateway status
- - Show / Hide from Dock
- - About / Quit
- Slightly format files (`swiftformat-for-xcode`)

Screenshots:

<img alt="Screenshot 2025-05-20 at 20 01 46" src="https://github.com/user-attachments/assets/9818718b-e939-422f-b28f-5eab95e1a7ff" width=45% /> <img alt="Screenshot 2025-05-20 at 20 01 29" src="https://github.com/user-attachments/assets/a5829950-79c7-4dcf-8677-fc52e4ef7f3b" width=45% /> 
